### PR TITLE
Fix bug on tutorial show page (when there are no associated videos)

### DIFF
--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,7 +1,7 @@
 <main class="tutorials">
 <h2><%= @facade.title %></h2>
 <h1 id="message"></h1>
-<div class="col col-4">
+<div class="col col-4" id="video-list">
   <h4>Videos</h4>
   <ul>
     <% @facade.videos.each do |video| %>
@@ -13,57 +13,60 @@
 </div>
 
 <div class="col col-8">
-  <div class="title-bookmark">
-    <h3><%= @facade.current_video.title %></h3>
-    <div class="bookmarks-btn">
-      <% if current_user %>
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
-      <% else %>
-      <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
-      <% end %>
+  <% if @facade.current_video %>
+    <div class="title-bookmark">
+      <h3><%= @facade.current_video.title %></h3>
+      <div class="bookmarks-btn">
+        <% if current_user %>
+        <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+        <% else %>
+        <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+        <% end %>
+      </div>
     </div>
-  </div>
 
-  <div id="player">
-    <script src="https://www.youtube.com/player_api"></script>
-    <script>
-    // create youtube player
-    var player;
-    var position;
-    function onYouTubePlayerAPIReady() {
-      player = new YT.Player('player', {
-        width: '640',
-        height: '390',
-        videoId: '<%= @facade.current_video.video_id %>',
-        events: {
-          onReady: onPlayerReady,
-          onStateChange: onPlayerStateChange
+    <div id="player">
+      <script src="https://www.youtube.com/player_api"></script>
+      <script>
+        // create youtube player
+        var player;
+        var position;
+        function onYouTubePlayerAPIReady() {
+          player = new YT.Player('player', {
+            width: '640',
+            height: '390',
+            videoId: '<%= @facade.current_video.video_id %>',
+            events: {
+              onReady: onPlayerReady,
+              onStateChange: onPlayerStateChange
+            }
+          });
         }
-      });
-    }
 
-    // autoplay video
-    function onPlayerReady(event) {
-      event.target.playVideo();
-    }
+        // autoplay video
+        function onPlayerReady(event) {
+          event.target.playVideo();
+        }
 
-    // when video ends
-    function onPlayerStateChange(event) {
-      if(event.data === 0 && <%= @facade.play_next_video? %>) {
-        window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
-      } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
-        const message = document.querySelector(`#message`);
-        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
-      }
-    }
-  </script>
+        // when video ends
+        function onPlayerStateChange(event) {
+          if(event.data === 0 && <%= @facade.play_next_video? %>) {
+            window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
+          } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
+            const message = document.querySelector(`#message`);
+            message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+          }
+        }
+      </script>
+    </div>
+
+    <h4>Description</h4>
+    <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
+      <%= @facade.current_video.description.truncate(50) %>...
+      <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
+    </p>
+  <% else %>
+    <h3>This tutorial has no videos</h3>
+  <% end %>
 </div>
-
-  <h4>Description</h4>
-  <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
-    <%= @facade.current_video.description.truncate(50) %>...
-    <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
-  </p>
-</div>
-
 </main>

--- a/spec/features/vistors/visitor_can_see_list_of_videos_for_a_tutorial_spec.rb
+++ b/spec/features/vistors/visitor_can_see_list_of_videos_for_a_tutorial_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'visitor visits tutorial show page' do
+  it 'sees a list of videos associated with that tutorial' do
+    tutorial = create(:tutorial)
+    video_1, video_2 = create_list(:video, 2, tutorial: tutorial)
+
+    visit "/tutorials/#{tutorial.id}"
+
+    within("#video-list") do
+      expect(page.all(".show-link").count).to eq(2)
+      expect(first(".show-link")).to have_content(video_1.title)
+    end
+  end
+
+  it 'does not error out when there are no videos for the tutorial' do
+    tutorial = create(:tutorial)
+
+    visit "/tutorials/#{tutorial.id}"
+
+    expect(page.all(".show-link").count).to eq(0)
+    expect(page).to have_content("This tutorial has no videos")
+  end
+end


### PR DESCRIPTION
Add `<% if @facade.current_video %>` to `views/tutorials/show.html.erb` so that the player isn't shown if there is no video. Add tests of the tutorial show page (with and without videos for the tutorial). Resolves #8.