### PR TITLE
Nil video position

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -4,4 +4,6 @@ class Video < ApplicationRecord
   has_many :user_videos
   has_many :users, through: :user_videos
   belongs_to :tutorial
+
+  validates_presence_of :position
 end

--- a/lib/tasks/video_nil_position_fix.rake
+++ b/lib/tasks/video_nil_position_fix.rake
@@ -1,0 +1,7 @@
+desc 'Override nil video positions'
+task video_nil_position_fix: :environment do
+  Video.where(position: nil).each do |video|
+    max_position = video.tutorial.videos.maximum(:position)
+    video.update(position: max_position + 1)
+  end
+end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Video, type: :model do
+  describe 'relationships' do
+    it { should have_many(:user_videos) }
+    it { should have_many(:users).through(:user_videos) }
+    it { should belong_to(:tutorial) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:position) }
+  end
+end


### PR DESCRIPTION
This branch...
 - Resolves #9 
 - Adds validation that a `Video` has a `position` -- cannot be nil
 - Adds model test of `Video`
 - Adds rake task script `video_nil_position_fix.rake` that increments the position on videos that have a nil position