### PR TITLE
Email invites

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -6,14 +6,18 @@ class InvitesController < ApplicationController
     invitee_handle = params[:github_handle]
     inviter_attributes = github_service.user_attributes(inviter_handle)
     invitee_attributes = github_service.user_attributes(invitee_handle)
-    invitee_email = invitee_attributes[:email]
-    if invitee_email
-      inviter_name = inviter_attributes[:name]
-      invitee_name = invitee_attributes[:name]
-      UserMailer.invite_email(inviter_name, invitee_name, invitee_email).deliver_later
-      flash[:success] = 'Successfully sent invite!'
+    if invitee_attributes.has_key?(:message)
+      flash[:danger] = "Failed to find the Github user with handle #{invitee_handle}"
     else
-      flash[:danger] = "The Github user you selected doesn't have an email address associated with their account."
+      invitee_email = invitee_attributes[:email]
+      if invitee_email
+        inviter_name = inviter_attributes[:name]
+        invitee_name = invitee_attributes[:name]
+        UserMailer.invite_email(inviter_name, invitee_name, invitee_email).deliver_later
+        flash[:success] = 'Successfully sent invite!'
+      else
+        flash[:danger] = "The Github user you selected doesn't have an email address associated with their account."
+      end
     end
     redirect_to dashboard_path
   end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,4 +1,7 @@
 class InvitesController < ApplicationController
-  def new
+  def new; end
+
+  def create
+    redirect_to dashboard_path
   end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -2,6 +2,7 @@ class InvitesController < ApplicationController
   def new; end
 
   def create
+    flash[:success] = 'Successfully sent invite!'
     redirect_to dashboard_path
   end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,0 +1,4 @@
+class InvitesController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -7,10 +7,14 @@ class InvitesController < ApplicationController
     inviter_attributes = github_service.user_attributes(inviter_handle)
     invitee_attributes = github_service.user_attributes(invitee_handle)
     invitee_email = invitee_attributes[:email]
-    inviter_name = inviter_attributes[:name]
-    invitee_name = invitee_attributes[:name]
-    UserMailer.invite_email(inviter_name, invitee_name, invitee_email).deliver_later
-    flash[:success] = 'Successfully sent invite!'
+    if invitee_email
+      inviter_name = inviter_attributes[:name]
+      invitee_name = invitee_attributes[:name]
+      UserMailer.invite_email(inviter_name, invitee_name, invitee_email).deliver_later
+      flash[:success] = 'Successfully sent invite!'
+    else
+      flash[:danger] = "The Github user you selected doesn't have an email address associated with their account."
+    end
     redirect_to dashboard_path
   end
 

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -2,8 +2,21 @@ class InvitesController < ApplicationController
   def new; end
 
   def create
-    UserMailer.invite_email(inviter, invitee)
+    inviter_handle = current_user.github_handle
+    invitee_handle = params[:github_handle]
+    inviter_attributes = github_service.user_attributes(inviter_handle)
+    invitee_attributes = github_service.user_attributes(invitee_handle)
+    invitee_email = invitee_attributes[:email]
+    inviter_name = inviter_attributes[:name]
+    invitee_name = invitee_attributes[:name]
+    UserMailer.invite_email(inviter_name, invitee_name, invitee_email).deliver_later
     flash[:success] = 'Successfully sent invite!'
     redirect_to dashboard_path
+  end
+
+  private
+
+  def github_service
+    @github_service ||= GithubApiService.new(current_user.github_token)
   end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -2,29 +2,10 @@ class InvitesController < ApplicationController
   def new; end
 
   def create
-    inviter_handle = current_user.github_handle
     invitee_handle = params[:github_handle]
-    inviter_attributes = github_service.user_attributes(inviter_handle)
-    invitee_attributes = github_service.user_attributes(invitee_handle)
-    if invitee_attributes.has_key?(:message)
-      flash[:danger] = "Failed to find the Github user with handle #{invitee_handle}"
-    else
-      invitee_email = invitee_attributes[:email]
-      if invitee_email
-        inviter_name = inviter_attributes[:name]
-        invitee_name = invitee_attributes[:name]
-        UserMailer.invite_email(inviter_name, invitee_name, invitee_email).deliver_later
-        flash[:success] = 'Successfully sent invite!'
-      else
-        flash[:danger] = "The Github user you selected doesn't have an email address associated with their account."
-      end
-    end
+    invite_maker = InviteMaker.new(current_user, invitee_handle)
+    invite_maker.setup_email
+    flash[invite_maker.flash.keys.first] = invite_maker.flash.values.first
     redirect_to dashboard_path
-  end
-
-  private
-
-  def github_service
-    @github_service ||= GithubApiService.new(current_user.github_token)
   end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -2,6 +2,7 @@ class InvitesController < ApplicationController
   def new; end
 
   def create
+    UserMailer.invite_email(inviter, invitee)
     flash[:success] = 'Successfully sent invite!'
     redirect_to dashboard_path
   end

--- a/app/facades/user_show_facade.rb
+++ b/app/facades/user_show_facade.rb
@@ -37,6 +37,6 @@ class UserShowFacade
   private
 
   def github_service
-    GithubApiService.new(@user.github_token)
+    @github_service ||= GithubApiService.new(@user.github_token)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,9 +4,9 @@ class UserMailer < ApplicationMailer
     mail(to: user.email, subject: 'Activate Your Account')
   end
 
-  def invite_email(inviter, invitee)
-    @inviter = inviter
-    @invitee = invitee
-    mail(to: @invitee.email, subject: 'Join Brownfield of Dreams!')
+  def invite_email(inviter_name, invitee_name, invitee_email)
+    @inviter_name = inviter_name
+    @invitee_name = invitee_name
+    mail(to: invitee_email, subject: 'Join Brownfield of Dreams!')
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,12 @@
 class UserMailer < ApplicationMailer
-
   def activation_email(user)
     @user = user
-    mail(to: user.email, subject: "Activate Your Account")
+    mail(to: user.email, subject: 'Activate Your Account')
+  end
+
+  def invite_email(inviter, invitee)
+    @inviter = inviter
+    @invitee = invitee
+    mail(to: @invitee.email, subject: 'Join Brownfield of Dreams!')
   end
 end

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -3,6 +3,7 @@
 class GithubUser
   attr_reader :handle,
               :url
+
   def initialize(attributes)
     @handle = attributes[:login]
     @url = attributes[:html_url]

--- a/app/models/invite_maker.rb
+++ b/app/models/invite_maker.rb
@@ -1,0 +1,45 @@
+class InviteMaker
+  attr_reader :flash
+
+  def initialize(current_user, invitee_handle)
+    @current_user = current_user
+    @invitee_handle = invitee_handle
+  end
+  
+  def setup_email
+    inviter_handle = @current_user.github_handle
+    inviter_attr = github_service.user_attributes(inviter_handle)
+    invitee_attr = github_service.user_attributes(@invitee_handle)
+    return if api_errors?(invitee_attr)
+    return if no_invitee_email?(invitee_attr)
+    send_mailer(inviter_attr, invitee_attr)
+  end
+
+  private
+
+  def github_service
+    @github_service ||= GithubApiService.new(@current_user.github_token)
+  end
+
+  def api_errors?(invitee_attr)
+    if invitee_attr.has_key?(:message)
+      @flash = { danger: "Failed to find the Github user with handle #{@invitee_handle}" }
+    end
+  end
+
+  def no_invitee_email?(invitee_attr)
+    if invitee_attr[:email]
+      @invitee_email = invitee_attr[:email]
+      false
+    else
+      @flash = { danger: "The Github user you selected doesn't have an email address associated with their account." }
+    end
+  end
+
+  def send_mailer(inviter_attr, invitee_attr)
+    inviter_name = inviter_attr[:name]
+    invitee_name = invitee_attr[:name]
+    UserMailer.invite_email(inviter_name, invitee_name, @invitee_email).deliver_later
+    @flash = { success: 'Successfully sent invite!' }
+  end
+end

--- a/app/services/github_api_service.rb
+++ b/app/services/github_api_service.rb
@@ -20,7 +20,7 @@ class GithubApiService
   private
 
   def conn
-    Faraday.new(url: 'https://api.github.com') do |f|
+    @conn ||= Faraday.new(url: 'https://api.github.com') do |f|
       f.adapter Faraday.default_adapter
     end
   end

--- a/app/services/github_api_service.rb
+++ b/app/services/github_api_service.rb
@@ -17,6 +17,10 @@ class GithubApiService
     fetch_data('/user/following')
   end
 
+  def user_attributes(github_handle)
+    fetch_data("/users/#{github_handle}")
+  end
+
   private
 
   def conn

--- a/app/views/invites/new.html.erb
+++ b/app/views/invites/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_tag(invites_path) do %>
+  <%= label_tag(:github_handle, "GitHub Handle") %>
+  <%= text_field_tag(:github_handle) %>
+  <%= submit_tag 'Send Invite' %>
+<% end %>

--- a/app/views/user_mailer/invite_email.html.erb
+++ b/app/views/user_mailer/invite_email.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @invitee_name %>,</p>
+
+<p><%= @inviter_name %> has invited you to join Brownfield of Dreams. You can create an account <%= link_to 'here', signup_url %>.</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,6 +5,7 @@
   <% unless current_github_user? %>
     <%= link_to "Connect to Github", "/auth/github", class: "btn btn-primary mb1 bg-teal" %>
   <% end %>
+  <%= link_to "Send an Invite", new_invite_path, class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>
     <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,10 +2,11 @@
   <h1> <%= current_user.first_name %>'s Dashboard </h1>
 
   <%= button_to 'Log Out', logout_path, method: 'delete', class: "btn btn-primary mb1 bg-teal" %>
-  <% unless current_github_user? %>
+  <% if current_github_user? %>
+    <%= link_to "Send an Invite", new_invite_path, class: "btn btn-primary mb1 bg-teal" %>
+  <% else %>
     <%= link_to "Connect to Github", "/auth/github", class: "btn btn-primary mb1 bg-teal" %>
   <% end %>
-  <%= link_to "Send an Invite", new_invite_path, class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>
     <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,6 +48,7 @@ Rails.application.configure do
 
   # Mailer will use local host to set urls in test environment
   config.action_mailer.default_url_options = { :host => 'localhost' }
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,7 +48,6 @@ Rails.application.configure do
 
   # Mailer will use local host to set urls in test environment
   config.action_mailer.default_url_options = { :host => 'localhost' }
-  config.action_mailer.delivery_method = :test
   config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = { address: 'localhost', port: 1025 }
 end

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,0 +1,1 @@
+ActionMailer::Base.delivery_method = :test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   get '/user/:user_id/activate', to: 'activation#create', as: :activate_user
 
   get '/invite', to: 'invites#new', as: :new_invite
+  post '/invite', to: 'invites#create', as: :invites
 
   resources :tutorials, only: %i[show index] do
     resources :videos, only: %i[show index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
 
   get '/user/:user_id/activate', to: 'activation#create', as: :activate_user
 
+  get '/invite', to: 'invites#new', as: :new_invite
+
   resources :tutorials, only: %i[show index] do
     resources :videos, only: %i[show index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
   get 'tags/:tag', to: 'welcome#index', as: :tag
   get '/register', to: 'users#new'
+  get '/signup', to: 'users#new'
 
   namespace :admin do
     get '/dashboard', to: 'dashboard#show'

--- a/spec/cassettes/github_api_user_attributes.yml
+++ b/spec/cassettes/github_api_user_attributes.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/chakeresa?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Jul 2019 23:59:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4950'
+      X-Ratelimit-Reset:
+      - '1562890459'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"cf041d49c113ecc7bac9882ecd61e228"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:25:54 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DA45:636C:2F8226:451690:5D27CD4E
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false,"name":"Alexandra
+        Chakeres","company":null,"blog":"https://www.linkedin.com/in/alexandrachakeres/","location":"Denver,
+        CO","email":"alexchakeres@gmail.com","hireable":null,"bio":"Back End Engineering
+        student at Turing School of Software & Design","public_repos":45,"public_gists":3,"followers":4,"following":1,"created_at":"2019-02-04T02:41:16Z","updated_at":"2019-07-11T23:25:54Z"}'
+    http_version: 
+  recorded_at: Thu, 11 Jul 2019 23:58:53 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/invite_github_user.yml
+++ b/spec/cassettes/invite_github_user.yml
@@ -596,4 +596,78 @@ http_interactions:
       string: '[{"login":"m-mrcr","id":28820023,"node_id":"MDQ6VXNlcjI4ODIwMDIz","avatar_url":"https://avatars3.githubusercontent.com/u/28820023?v=4","gravatar_id":"","url":"https://api.github.com/users/m-mrcr","html_url":"https://github.com/m-mrcr","followers_url":"https://api.github.com/users/m-mrcr/followers","following_url":"https://api.github.com/users/m-mrcr/following{/other_user}","gists_url":"https://api.github.com/users/m-mrcr/gists{/gist_id}","starred_url":"https://api.github.com/users/m-mrcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/m-mrcr/subscriptions","organizations_url":"https://api.github.com/users/m-mrcr/orgs","repos_url":"https://api.github.com/users/m-mrcr/repos","events_url":"https://api.github.com/users/m-mrcr/events{/privacy}","received_events_url":"https://api.github.com/users/m-mrcr/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false},{"login":"milevy1","id":36040194,"node_id":"MDQ6VXNlcjM2MDQwMTk0","avatar_url":"https://avatars3.githubusercontent.com/u/36040194?v=4","gravatar_id":"","url":"https://api.github.com/users/milevy1","html_url":"https://github.com/milevy1","followers_url":"https://api.github.com/users/milevy1/followers","following_url":"https://api.github.com/users/milevy1/following{/other_user}","gists_url":"https://api.github.com/users/milevy1/gists{/gist_id}","starred_url":"https://api.github.com/users/milevy1/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/milevy1/subscriptions","organizations_url":"https://api.github.com/users/milevy1/orgs","repos_url":"https://api.github.com/users/milevy1/repos","events_url":"https://api.github.com/users/milevy1/events{/privacy}","received_events_url":"https://api.github.com/users/milevy1/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"smainar","id":43945779,"node_id":"MDQ6VXNlcjQzOTQ1Nzc5","avatar_url":"https://avatars3.githubusercontent.com/u/43945779?v=4","gravatar_id":"","url":"https://api.github.com/users/smainar","html_url":"https://github.com/smainar","followers_url":"https://api.github.com/users/smainar/followers","following_url":"https://api.github.com/users/smainar/following{/other_user}","gists_url":"https://api.github.com/users/smainar/gists{/gist_id}","starred_url":"https://api.github.com/users/smainar/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/smainar/subscriptions","organizations_url":"https://api.github.com/users/smainar/orgs","repos_url":"https://api.github.com/users/smainar/repos","events_url":"https://api.github.com/users/smainar/events{/privacy}","received_events_url":"https://api.github.com/users/smainar/received_events","type":"User","site_admin":false},{"login":"carriewalsh","id":43975624,"node_id":"MDQ6VXNlcjQzOTc1NjI0","avatar_url":"https://avatars0.githubusercontent.com/u/43975624?v=4","gravatar_id":"","url":"https://api.github.com/users/carriewalsh","html_url":"https://github.com/carriewalsh","followers_url":"https://api.github.com/users/carriewalsh/followers","following_url":"https://api.github.com/users/carriewalsh/following{/other_user}","gists_url":"https://api.github.com/users/carriewalsh/gists{/gist_id}","starred_url":"https://api.github.com/users/carriewalsh/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/carriewalsh/subscriptions","organizations_url":"https://api.github.com/users/carriewalsh/orgs","repos_url":"https://api.github.com/users/carriewalsh/repos","events_url":"https://api.github.com/users/carriewalsh/events{/privacy}","received_events_url":"https://api.github.com/users/carriewalsh/received_events","type":"User","site_admin":false},{"login":"Loomus","id":44850604,"node_id":"MDQ6VXNlcjQ0ODUwNjA0","avatar_url":"https://avatars0.githubusercontent.com/u/44850604?v=4","gravatar_id":"","url":"https://api.github.com/users/Loomus","html_url":"https://github.com/Loomus","followers_url":"https://api.github.com/users/Loomus/followers","following_url":"https://api.github.com/users/Loomus/following{/other_user}","gists_url":"https://api.github.com/users/Loomus/gists{/gist_id}","starred_url":"https://api.github.com/users/Loomus/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Loomus/subscriptions","organizations_url":"https://api.github.com/users/Loomus/orgs","repos_url":"https://api.github.com/users/Loomus/repos","events_url":"https://api.github.com/users/Loomus/events{/privacy}","received_events_url":"https://api.github.com/users/Loomus/received_events","type":"User","site_admin":false},{"login":"james-cape","id":46202598,"node_id":"MDQ6VXNlcjQ2MjAyNTk4","avatar_url":"https://avatars2.githubusercontent.com/u/46202598?v=4","gravatar_id":"","url":"https://api.github.com/users/james-cape","html_url":"https://github.com/james-cape","followers_url":"https://api.github.com/users/james-cape/followers","following_url":"https://api.github.com/users/james-cape/following{/other_user}","gists_url":"https://api.github.com/users/james-cape/gists{/gist_id}","starred_url":"https://api.github.com/users/james-cape/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/james-cape/subscriptions","organizations_url":"https://api.github.com/users/james-cape/orgs","repos_url":"https://api.github.com/users/james-cape/repos","events_url":"https://api.github.com/users/james-cape/events{/privacy}","received_events_url":"https://api.github.com/users/james-cape/received_events","type":"User","site_admin":false},{"login":"alexander-mathieu","id":47018937,"node_id":"MDQ6VXNlcjQ3MDE4OTM3","avatar_url":"https://avatars3.githubusercontent.com/u/47018937?v=4","gravatar_id":"","url":"https://api.github.com/users/alexander-mathieu","html_url":"https://github.com/alexander-mathieu","followers_url":"https://api.github.com/users/alexander-mathieu/followers","following_url":"https://api.github.com/users/alexander-mathieu/following{/other_user}","gists_url":"https://api.github.com/users/alexander-mathieu/gists{/gist_id}","starred_url":"https://api.github.com/users/alexander-mathieu/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/alexander-mathieu/subscriptions","organizations_url":"https://api.github.com/users/alexander-mathieu/orgs","repos_url":"https://api.github.com/users/alexander-mathieu/repos","events_url":"https://api.github.com/users/alexander-mathieu/events{/privacy}","received_events_url":"https://api.github.com/users/alexander-mathieu/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false}]'
     http_version: 
   recorded_at: Fri, 12 Jul 2019 00:11:43 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 19:37:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4999'
+      X-Ratelimit-Reset:
+      - '1562963852'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F565:34BB:11CFA55:2197374:5D28E17C
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 19:37:13 GMT
 recorded_with: VCR 5.0.0

--- a/spec/cassettes/invite_github_user.yml
+++ b/spec/cassettes/invite_github_user.yml
@@ -1,0 +1,599 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=1&per_page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:11:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4999'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"2cb8a82e98751c79d91daec999a32378"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Link:
+      - <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=2&per_page=5>;
+        rel="next", <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=15&per_page=5>;
+        rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E6EF:67B9:298CA7:3D9906:5D27D04A
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":194746869,"node_id":"MDEwOlJlcG9zaXRvcnkxOTQ3NDY4Njk=","name":"brownfield-of-dreams","full_name":"chakeresa/brownfield-of-dreams","private":false,"owner":{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},"html_url":"https://github.com/chakeresa/brownfield-of-dreams","description":"Rails
+        app used for hosting video tutorials and classes. Serves as the base repository
+        for a B3 project.","fork":true,"url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams","forks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/forks","keys_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/keys{/key_id}","collaborators_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/teams","hooks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/hooks","issue_events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/events{/number}","events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/events","assignees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/assignees{/user}","branches_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/branches{/branch}","tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/tags","blobs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/refs{/sha}","trees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/trees{/sha}","statuses_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/statuses/{sha}","languages_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/languages","stargazers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/stargazers","contributors_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contributors","subscribers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscribers","subscription_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscription","commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/commits{/sha}","git_commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/commits{/sha}","comments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/comments{/number}","issue_comment_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/comments{/number}","contents_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contents/{+path}","compare_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/compare/{base}...{head}","merges_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/merges","archive_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/downloads","issues_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues{/number}","pulls_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/pulls{/number}","milestones_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/milestones{/number}","notifications_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/labels{/name}","releases_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/releases{/id}","deployments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/deployments","created_at":"2019-07-01T21:43:22Z","updated_at":"2019-07-11T20:54:44Z","pushed_at":"2019-07-12T00:01:23Z","git_url":"git://github.com/chakeresa/brownfield-of-dreams.git","ssh_url":"git@github.com:chakeresa/brownfield-of-dreams.git","clone_url":"https://github.com/chakeresa/brownfield-of-dreams.git","svn_url":"https://github.com/chakeresa/brownfield-of-dreams","homepage":"","size":7735,"stargazers_count":2,"watchers_count":2,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":6,"license":null,"forks":0,"open_issues":6,"watchers":2,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":168045397,"node_id":"MDEwOlJlcG9zaXRvcnkxNjgwNDUzOTc=","name":"battleship","full_name":"jalena-penaligon/battleship","private":false,"owner":{"login":"jalena-penaligon","id":45905026,"node_id":"MDQ6VXNlcjQ1OTA1MDI2","avatar_url":"https://avatars0.githubusercontent.com/u/45905026?v=4","gravatar_id":"","url":"https://api.github.com/users/jalena-penaligon","html_url":"https://github.com/jalena-penaligon","followers_url":"https://api.github.com/users/jalena-penaligon/followers","following_url":"https://api.github.com/users/jalena-penaligon/following{/other_user}","gists_url":"https://api.github.com/users/jalena-penaligon/gists{/gist_id}","starred_url":"https://api.github.com/users/jalena-penaligon/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jalena-penaligon/subscriptions","organizations_url":"https://api.github.com/users/jalena-penaligon/orgs","repos_url":"https://api.github.com/users/jalena-penaligon/repos","events_url":"https://api.github.com/users/jalena-penaligon/events{/privacy}","received_events_url":"https://api.github.com/users/jalena-penaligon/received_events","type":"User","site_admin":false},"html_url":"https://github.com/jalena-penaligon/battleship","description":null,"fork":false,"url":"https://api.github.com/repos/jalena-penaligon/battleship","forks_url":"https://api.github.com/repos/jalena-penaligon/battleship/forks","keys_url":"https://api.github.com/repos/jalena-penaligon/battleship/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jalena-penaligon/battleship/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jalena-penaligon/battleship/teams","hooks_url":"https://api.github.com/repos/jalena-penaligon/battleship/hooks","issue_events_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/events{/number}","events_url":"https://api.github.com/repos/jalena-penaligon/battleship/events","assignees_url":"https://api.github.com/repos/jalena-penaligon/battleship/assignees{/user}","branches_url":"https://api.github.com/repos/jalena-penaligon/battleship/branches{/branch}","tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/tags","blobs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/refs{/sha}","trees_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jalena-penaligon/battleship/statuses/{sha}","languages_url":"https://api.github.com/repos/jalena-penaligon/battleship/languages","stargazers_url":"https://api.github.com/repos/jalena-penaligon/battleship/stargazers","contributors_url":"https://api.github.com/repos/jalena-penaligon/battleship/contributors","subscribers_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscribers","subscription_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscription","commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/commits{/sha}","git_commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/commits{/sha}","comments_url":"https://api.github.com/repos/jalena-penaligon/battleship/comments{/number}","issue_comment_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/comments{/number}","contents_url":"https://api.github.com/repos/jalena-penaligon/battleship/contents/{+path}","compare_url":"https://api.github.com/repos/jalena-penaligon/battleship/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jalena-penaligon/battleship/merges","archive_url":"https://api.github.com/repos/jalena-penaligon/battleship/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jalena-penaligon/battleship/downloads","issues_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues{/number}","pulls_url":"https://api.github.com/repos/jalena-penaligon/battleship/pulls{/number}","milestones_url":"https://api.github.com/repos/jalena-penaligon/battleship/milestones{/number}","notifications_url":"https://api.github.com/repos/jalena-penaligon/battleship/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jalena-penaligon/battleship/labels{/name}","releases_url":"https://api.github.com/repos/jalena-penaligon/battleship/releases{/id}","deployments_url":"https://api.github.com/repos/jalena-penaligon/battleship/deployments","created_at":"2019-01-28T22:04:39Z","updated_at":"2019-02-06T19:57:18Z","pushed_at":"2019-02-06T19:57:17Z","git_url":"git://github.com/jalena-penaligon/battleship.git","ssh_url":"git@github.com:jalena-penaligon/battleship.git","clone_url":"https://github.com/jalena-penaligon/battleship.git","svn_url":"https://github.com/jalena-penaligon/battleship","homepage":null,"size":59,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":176382436,"node_id":"MDEwOlJlcG9zaXRvcnkxNzYzODI0MzY=","name":"Battleship_project","full_name":"kylecornelissen/Battleship_project","private":false,"owner":{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},"html_url":"https://github.com/kylecornelissen/Battleship_project","description":null,"fork":false,"url":"https://api.github.com/repos/kylecornelissen/Battleship_project","forks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/forks","keys_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/keys{/key_id}","collaborators_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/teams","hooks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/hooks","issue_events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/events{/number}","events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/events","assignees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/assignees{/user}","branches_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/branches{/branch}","tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/tags","blobs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/refs{/sha}","trees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/trees{/sha}","statuses_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/statuses/{sha}","languages_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/languages","stargazers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/stargazers","contributors_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contributors","subscribers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscribers","subscription_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscription","commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/commits{/sha}","git_commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/commits{/sha}","comments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/comments{/number}","issue_comment_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/comments{/number}","contents_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contents/{+path}","compare_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/compare/{base}...{head}","merges_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/merges","archive_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/downloads","issues_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues{/number}","pulls_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/pulls{/number}","milestones_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/milestones{/number}","notifications_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/labels{/name}","releases_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/releases{/id}","deployments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/deployments","created_at":"2019-03-18T22:57:32Z","updated_at":"2019-03-28T02:16:44Z","pushed_at":"2019-03-28T02:16:43Z","git_url":"git://github.com/kylecornelissen/Battleship_project.git","ssh_url":"git@github.com:kylecornelissen/Battleship_project.git","clone_url":"https://github.com/kylecornelissen/Battleship_project.git","svn_url":"https://github.com/kylecornelissen/Battleship_project","homepage":null,"size":73,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":181714029,"node_id":"MDEwOlJlcG9zaXRvcnkxODE3MTQwMjk=","name":"1903_final","full_name":"MillsProvosty/1903_final","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/1903_final","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/1903_final","forks_url":"https://api.github.com/repos/MillsProvosty/1903_final/forks","keys_url":"https://api.github.com/repos/MillsProvosty/1903_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/1903_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/1903_final/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/1903_final/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/1903_final/events","assignees_url":"https://api.github.com/repos/MillsProvosty/1903_final/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/1903_final/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/1903_final/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/1903_final/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/1903_final/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/1903_final/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/1903_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/1903_final/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/1903_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/1903_final/merges","archive_url":"https://api.github.com/repos/MillsProvosty/1903_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/1903_final/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/1903_final/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/1903_final/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/1903_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/1903_final/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/1903_final/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/1903_final/deployments","created_at":"2019-04-16T15:11:02Z","updated_at":"2019-04-16T18:10:48Z","pushed_at":"2019-04-16T18:10:46Z","git_url":"git://github.com/MillsProvosty/1903_final.git","ssh_url":"git@github.com:MillsProvosty/1903_final.git","clone_url":"https://github.com/MillsProvosty/1903_final.git","svn_url":"https://github.com/MillsProvosty/1903_final","homepage":null,"size":8,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}},{"id":184634926,"node_id":"MDEwOlJlcG9zaXRvcnkxODQ2MzQ5MjY=","name":"activerecord-obstacle-course","full_name":"MillsProvosty/activerecord-obstacle-course","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course","forks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/forks","keys_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/events","assignees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/merges","archive_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/deployments","created_at":"2019-05-02T18:53:23Z","updated_at":"2019-05-31T17:00:15Z","pushed_at":"2019-05-31T17:00:14Z","git_url":"git://github.com/MillsProvosty/activerecord-obstacle-course.git","ssh_url":"git@github.com:MillsProvosty/activerecord-obstacle-course.git","clone_url":"https://github.com/MillsProvosty/activerecord-obstacle-course.git","svn_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","homepage":null,"size":54,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:38 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/followers?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:11:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4998'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"de3cc92700f1038013e3888d075e7b40"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E6F0:7979:3CB5D3:5C00A9:5D27D04B
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"ryanmillergm","id":42855291,"node_id":"MDQ6VXNlcjQyODU1Mjkx","avatar_url":"https://avatars0.githubusercontent.com/u/42855291?v=4","gravatar_id":"","url":"https://api.github.com/users/ryanmillergm","html_url":"https://github.com/ryanmillergm","followers_url":"https://api.github.com/users/ryanmillergm/followers","following_url":"https://api.github.com/users/ryanmillergm/following{/other_user}","gists_url":"https://api.github.com/users/ryanmillergm/gists{/gist_id}","starred_url":"https://api.github.com/users/ryanmillergm/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ryanmillergm/subscriptions","organizations_url":"https://api.github.com/users/ryanmillergm/orgs","repos_url":"https://api.github.com/users/ryanmillergm/repos","events_url":"https://api.github.com/users/ryanmillergm/events{/privacy}","received_events_url":"https://api.github.com/users/ryanmillergm/received_events","type":"User","site_admin":false},{"login":"n-flint","id":34421236,"node_id":"MDQ6VXNlcjM0NDIxMjM2","avatar_url":"https://avatars3.githubusercontent.com/u/34421236?v=4","gravatar_id":"","url":"https://api.github.com/users/n-flint","html_url":"https://github.com/n-flint","followers_url":"https://api.github.com/users/n-flint/followers","following_url":"https://api.github.com/users/n-flint/following{/other_user}","gists_url":"https://api.github.com/users/n-flint/gists{/gist_id}","starred_url":"https://api.github.com/users/n-flint/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/n-flint/subscriptions","organizations_url":"https://api.github.com/users/n-flint/orgs","repos_url":"https://api.github.com/users/n-flint/repos","events_url":"https://api.github.com/users/n-flint/events{/privacy}","received_events_url":"https://api.github.com/users/n-flint/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:38 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/following?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:11:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4997'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"860bc567e35e6a4bb121ca4217b7420d"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E6F5:0397:37EDAA:54C184:5D27D04C
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"m-mrcr","id":28820023,"node_id":"MDQ6VXNlcjI4ODIwMDIz","avatar_url":"https://avatars3.githubusercontent.com/u/28820023?v=4","gravatar_id":"","url":"https://api.github.com/users/m-mrcr","html_url":"https://github.com/m-mrcr","followers_url":"https://api.github.com/users/m-mrcr/followers","following_url":"https://api.github.com/users/m-mrcr/following{/other_user}","gists_url":"https://api.github.com/users/m-mrcr/gists{/gist_id}","starred_url":"https://api.github.com/users/m-mrcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/m-mrcr/subscriptions","organizations_url":"https://api.github.com/users/m-mrcr/orgs","repos_url":"https://api.github.com/users/m-mrcr/repos","events_url":"https://api.github.com/users/m-mrcr/events{/privacy}","received_events_url":"https://api.github.com/users/m-mrcr/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false},{"login":"milevy1","id":36040194,"node_id":"MDQ6VXNlcjM2MDQwMTk0","avatar_url":"https://avatars3.githubusercontent.com/u/36040194?v=4","gravatar_id":"","url":"https://api.github.com/users/milevy1","html_url":"https://github.com/milevy1","followers_url":"https://api.github.com/users/milevy1/followers","following_url":"https://api.github.com/users/milevy1/following{/other_user}","gists_url":"https://api.github.com/users/milevy1/gists{/gist_id}","starred_url":"https://api.github.com/users/milevy1/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/milevy1/subscriptions","organizations_url":"https://api.github.com/users/milevy1/orgs","repos_url":"https://api.github.com/users/milevy1/repos","events_url":"https://api.github.com/users/milevy1/events{/privacy}","received_events_url":"https://api.github.com/users/milevy1/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"smainar","id":43945779,"node_id":"MDQ6VXNlcjQzOTQ1Nzc5","avatar_url":"https://avatars3.githubusercontent.com/u/43945779?v=4","gravatar_id":"","url":"https://api.github.com/users/smainar","html_url":"https://github.com/smainar","followers_url":"https://api.github.com/users/smainar/followers","following_url":"https://api.github.com/users/smainar/following{/other_user}","gists_url":"https://api.github.com/users/smainar/gists{/gist_id}","starred_url":"https://api.github.com/users/smainar/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/smainar/subscriptions","organizations_url":"https://api.github.com/users/smainar/orgs","repos_url":"https://api.github.com/users/smainar/repos","events_url":"https://api.github.com/users/smainar/events{/privacy}","received_events_url":"https://api.github.com/users/smainar/received_events","type":"User","site_admin":false},{"login":"carriewalsh","id":43975624,"node_id":"MDQ6VXNlcjQzOTc1NjI0","avatar_url":"https://avatars0.githubusercontent.com/u/43975624?v=4","gravatar_id":"","url":"https://api.github.com/users/carriewalsh","html_url":"https://github.com/carriewalsh","followers_url":"https://api.github.com/users/carriewalsh/followers","following_url":"https://api.github.com/users/carriewalsh/following{/other_user}","gists_url":"https://api.github.com/users/carriewalsh/gists{/gist_id}","starred_url":"https://api.github.com/users/carriewalsh/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/carriewalsh/subscriptions","organizations_url":"https://api.github.com/users/carriewalsh/orgs","repos_url":"https://api.github.com/users/carriewalsh/repos","events_url":"https://api.github.com/users/carriewalsh/events{/privacy}","received_events_url":"https://api.github.com/users/carriewalsh/received_events","type":"User","site_admin":false},{"login":"Loomus","id":44850604,"node_id":"MDQ6VXNlcjQ0ODUwNjA0","avatar_url":"https://avatars0.githubusercontent.com/u/44850604?v=4","gravatar_id":"","url":"https://api.github.com/users/Loomus","html_url":"https://github.com/Loomus","followers_url":"https://api.github.com/users/Loomus/followers","following_url":"https://api.github.com/users/Loomus/following{/other_user}","gists_url":"https://api.github.com/users/Loomus/gists{/gist_id}","starred_url":"https://api.github.com/users/Loomus/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Loomus/subscriptions","organizations_url":"https://api.github.com/users/Loomus/orgs","repos_url":"https://api.github.com/users/Loomus/repos","events_url":"https://api.github.com/users/Loomus/events{/privacy}","received_events_url":"https://api.github.com/users/Loomus/received_events","type":"User","site_admin":false},{"login":"james-cape","id":46202598,"node_id":"MDQ6VXNlcjQ2MjAyNTk4","avatar_url":"https://avatars2.githubusercontent.com/u/46202598?v=4","gravatar_id":"","url":"https://api.github.com/users/james-cape","html_url":"https://github.com/james-cape","followers_url":"https://api.github.com/users/james-cape/followers","following_url":"https://api.github.com/users/james-cape/following{/other_user}","gists_url":"https://api.github.com/users/james-cape/gists{/gist_id}","starred_url":"https://api.github.com/users/james-cape/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/james-cape/subscriptions","organizations_url":"https://api.github.com/users/james-cape/orgs","repos_url":"https://api.github.com/users/james-cape/repos","events_url":"https://api.github.com/users/james-cape/events{/privacy}","received_events_url":"https://api.github.com/users/james-cape/received_events","type":"User","site_admin":false},{"login":"alexander-mathieu","id":47018937,"node_id":"MDQ6VXNlcjQ3MDE4OTM3","avatar_url":"https://avatars3.githubusercontent.com/u/47018937?v=4","gravatar_id":"","url":"https://api.github.com/users/alexander-mathieu","html_url":"https://github.com/alexander-mathieu","followers_url":"https://api.github.com/users/alexander-mathieu/followers","following_url":"https://api.github.com/users/alexander-mathieu/following{/other_user}","gists_url":"https://api.github.com/users/alexander-mathieu/gists{/gist_id}","starred_url":"https://api.github.com/users/alexander-mathieu/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/alexander-mathieu/subscriptions","organizations_url":"https://api.github.com/users/alexander-mathieu/orgs","repos_url":"https://api.github.com/users/alexander-mathieu/repos","events_url":"https://api.github.com/users/alexander-mathieu/events{/privacy}","received_events_url":"https://api.github.com/users/alexander-mathieu/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:39 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:11:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4996'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E6F6:5B89:392CC1:56B044:5D27D04C
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:39 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/chakeresa?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:11:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4995'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"cf041d49c113ecc7bac9882ecd61e228"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:25:54 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E6FB:5BB3:1E2EB2:2C3B5A:5D27D04E
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false,"name":"Alexandra
+        Chakeres","company":null,"blog":"https://www.linkedin.com/in/alexandrachakeres/","location":"Denver,
+        CO","email":"alexchakeres@gmail.com","hireable":null,"bio":"Back End Engineering
+        student at Turing School of Software & Design","public_repos":45,"public_gists":3,"followers":4,"following":1,"created_at":"2019-02-04T02:41:16Z","updated_at":"2019-07-11T23:25:54Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:41 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=1&per_page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:11:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4994'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"2cb8a82e98751c79d91daec999a32378"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Link:
+      - <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=2&per_page=5>;
+        rel="next", <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=15&per_page=5>;
+        rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E708:4B04:1D2688:2AEF0E:5D27D04E
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":194746869,"node_id":"MDEwOlJlcG9zaXRvcnkxOTQ3NDY4Njk=","name":"brownfield-of-dreams","full_name":"chakeresa/brownfield-of-dreams","private":false,"owner":{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},"html_url":"https://github.com/chakeresa/brownfield-of-dreams","description":"Rails
+        app used for hosting video tutorials and classes. Serves as the base repository
+        for a B3 project.","fork":true,"url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams","forks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/forks","keys_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/keys{/key_id}","collaborators_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/teams","hooks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/hooks","issue_events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/events{/number}","events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/events","assignees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/assignees{/user}","branches_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/branches{/branch}","tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/tags","blobs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/refs{/sha}","trees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/trees{/sha}","statuses_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/statuses/{sha}","languages_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/languages","stargazers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/stargazers","contributors_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contributors","subscribers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscribers","subscription_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscription","commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/commits{/sha}","git_commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/commits{/sha}","comments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/comments{/number}","issue_comment_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/comments{/number}","contents_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contents/{+path}","compare_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/compare/{base}...{head}","merges_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/merges","archive_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/downloads","issues_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues{/number}","pulls_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/pulls{/number}","milestones_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/milestones{/number}","notifications_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/labels{/name}","releases_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/releases{/id}","deployments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/deployments","created_at":"2019-07-01T21:43:22Z","updated_at":"2019-07-11T20:54:44Z","pushed_at":"2019-07-12T00:01:23Z","git_url":"git://github.com/chakeresa/brownfield-of-dreams.git","ssh_url":"git@github.com:chakeresa/brownfield-of-dreams.git","clone_url":"https://github.com/chakeresa/brownfield-of-dreams.git","svn_url":"https://github.com/chakeresa/brownfield-of-dreams","homepage":"","size":7735,"stargazers_count":2,"watchers_count":2,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":6,"license":null,"forks":0,"open_issues":6,"watchers":2,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":168045397,"node_id":"MDEwOlJlcG9zaXRvcnkxNjgwNDUzOTc=","name":"battleship","full_name":"jalena-penaligon/battleship","private":false,"owner":{"login":"jalena-penaligon","id":45905026,"node_id":"MDQ6VXNlcjQ1OTA1MDI2","avatar_url":"https://avatars0.githubusercontent.com/u/45905026?v=4","gravatar_id":"","url":"https://api.github.com/users/jalena-penaligon","html_url":"https://github.com/jalena-penaligon","followers_url":"https://api.github.com/users/jalena-penaligon/followers","following_url":"https://api.github.com/users/jalena-penaligon/following{/other_user}","gists_url":"https://api.github.com/users/jalena-penaligon/gists{/gist_id}","starred_url":"https://api.github.com/users/jalena-penaligon/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jalena-penaligon/subscriptions","organizations_url":"https://api.github.com/users/jalena-penaligon/orgs","repos_url":"https://api.github.com/users/jalena-penaligon/repos","events_url":"https://api.github.com/users/jalena-penaligon/events{/privacy}","received_events_url":"https://api.github.com/users/jalena-penaligon/received_events","type":"User","site_admin":false},"html_url":"https://github.com/jalena-penaligon/battleship","description":null,"fork":false,"url":"https://api.github.com/repos/jalena-penaligon/battleship","forks_url":"https://api.github.com/repos/jalena-penaligon/battleship/forks","keys_url":"https://api.github.com/repos/jalena-penaligon/battleship/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jalena-penaligon/battleship/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jalena-penaligon/battleship/teams","hooks_url":"https://api.github.com/repos/jalena-penaligon/battleship/hooks","issue_events_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/events{/number}","events_url":"https://api.github.com/repos/jalena-penaligon/battleship/events","assignees_url":"https://api.github.com/repos/jalena-penaligon/battleship/assignees{/user}","branches_url":"https://api.github.com/repos/jalena-penaligon/battleship/branches{/branch}","tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/tags","blobs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/refs{/sha}","trees_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jalena-penaligon/battleship/statuses/{sha}","languages_url":"https://api.github.com/repos/jalena-penaligon/battleship/languages","stargazers_url":"https://api.github.com/repos/jalena-penaligon/battleship/stargazers","contributors_url":"https://api.github.com/repos/jalena-penaligon/battleship/contributors","subscribers_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscribers","subscription_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscription","commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/commits{/sha}","git_commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/commits{/sha}","comments_url":"https://api.github.com/repos/jalena-penaligon/battleship/comments{/number}","issue_comment_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/comments{/number}","contents_url":"https://api.github.com/repos/jalena-penaligon/battleship/contents/{+path}","compare_url":"https://api.github.com/repos/jalena-penaligon/battleship/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jalena-penaligon/battleship/merges","archive_url":"https://api.github.com/repos/jalena-penaligon/battleship/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jalena-penaligon/battleship/downloads","issues_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues{/number}","pulls_url":"https://api.github.com/repos/jalena-penaligon/battleship/pulls{/number}","milestones_url":"https://api.github.com/repos/jalena-penaligon/battleship/milestones{/number}","notifications_url":"https://api.github.com/repos/jalena-penaligon/battleship/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jalena-penaligon/battleship/labels{/name}","releases_url":"https://api.github.com/repos/jalena-penaligon/battleship/releases{/id}","deployments_url":"https://api.github.com/repos/jalena-penaligon/battleship/deployments","created_at":"2019-01-28T22:04:39Z","updated_at":"2019-02-06T19:57:18Z","pushed_at":"2019-02-06T19:57:17Z","git_url":"git://github.com/jalena-penaligon/battleship.git","ssh_url":"git@github.com:jalena-penaligon/battleship.git","clone_url":"https://github.com/jalena-penaligon/battleship.git","svn_url":"https://github.com/jalena-penaligon/battleship","homepage":null,"size":59,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":176382436,"node_id":"MDEwOlJlcG9zaXRvcnkxNzYzODI0MzY=","name":"Battleship_project","full_name":"kylecornelissen/Battleship_project","private":false,"owner":{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},"html_url":"https://github.com/kylecornelissen/Battleship_project","description":null,"fork":false,"url":"https://api.github.com/repos/kylecornelissen/Battleship_project","forks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/forks","keys_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/keys{/key_id}","collaborators_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/teams","hooks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/hooks","issue_events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/events{/number}","events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/events","assignees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/assignees{/user}","branches_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/branches{/branch}","tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/tags","blobs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/refs{/sha}","trees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/trees{/sha}","statuses_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/statuses/{sha}","languages_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/languages","stargazers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/stargazers","contributors_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contributors","subscribers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscribers","subscription_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscription","commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/commits{/sha}","git_commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/commits{/sha}","comments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/comments{/number}","issue_comment_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/comments{/number}","contents_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contents/{+path}","compare_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/compare/{base}...{head}","merges_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/merges","archive_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/downloads","issues_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues{/number}","pulls_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/pulls{/number}","milestones_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/milestones{/number}","notifications_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/labels{/name}","releases_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/releases{/id}","deployments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/deployments","created_at":"2019-03-18T22:57:32Z","updated_at":"2019-03-28T02:16:44Z","pushed_at":"2019-03-28T02:16:43Z","git_url":"git://github.com/kylecornelissen/Battleship_project.git","ssh_url":"git@github.com:kylecornelissen/Battleship_project.git","clone_url":"https://github.com/kylecornelissen/Battleship_project.git","svn_url":"https://github.com/kylecornelissen/Battleship_project","homepage":null,"size":73,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":181714029,"node_id":"MDEwOlJlcG9zaXRvcnkxODE3MTQwMjk=","name":"1903_final","full_name":"MillsProvosty/1903_final","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/1903_final","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/1903_final","forks_url":"https://api.github.com/repos/MillsProvosty/1903_final/forks","keys_url":"https://api.github.com/repos/MillsProvosty/1903_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/1903_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/1903_final/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/1903_final/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/1903_final/events","assignees_url":"https://api.github.com/repos/MillsProvosty/1903_final/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/1903_final/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/1903_final/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/1903_final/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/1903_final/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/1903_final/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/1903_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/1903_final/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/1903_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/1903_final/merges","archive_url":"https://api.github.com/repos/MillsProvosty/1903_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/1903_final/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/1903_final/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/1903_final/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/1903_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/1903_final/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/1903_final/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/1903_final/deployments","created_at":"2019-04-16T15:11:02Z","updated_at":"2019-04-16T18:10:48Z","pushed_at":"2019-04-16T18:10:46Z","git_url":"git://github.com/MillsProvosty/1903_final.git","ssh_url":"git@github.com:MillsProvosty/1903_final.git","clone_url":"https://github.com/MillsProvosty/1903_final.git","svn_url":"https://github.com/MillsProvosty/1903_final","homepage":null,"size":8,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}},{"id":184634926,"node_id":"MDEwOlJlcG9zaXRvcnkxODQ2MzQ5MjY=","name":"activerecord-obstacle-course","full_name":"MillsProvosty/activerecord-obstacle-course","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course","forks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/forks","keys_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/events","assignees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/merges","archive_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/deployments","created_at":"2019-05-02T18:53:23Z","updated_at":"2019-05-31T17:00:15Z","pushed_at":"2019-05-31T17:00:14Z","git_url":"git://github.com/MillsProvosty/activerecord-obstacle-course.git","ssh_url":"git@github.com:MillsProvosty/activerecord-obstacle-course.git","clone_url":"https://github.com/MillsProvosty/activerecord-obstacle-course.git","svn_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","homepage":null,"size":54,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:42 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/followers?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:11:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4993'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"de3cc92700f1038013e3888d075e7b40"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E709:7469:CAC10:127BAC:5D27D04F
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"ryanmillergm","id":42855291,"node_id":"MDQ6VXNlcjQyODU1Mjkx","avatar_url":"https://avatars0.githubusercontent.com/u/42855291?v=4","gravatar_id":"","url":"https://api.github.com/users/ryanmillergm","html_url":"https://github.com/ryanmillergm","followers_url":"https://api.github.com/users/ryanmillergm/followers","following_url":"https://api.github.com/users/ryanmillergm/following{/other_user}","gists_url":"https://api.github.com/users/ryanmillergm/gists{/gist_id}","starred_url":"https://api.github.com/users/ryanmillergm/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ryanmillergm/subscriptions","organizations_url":"https://api.github.com/users/ryanmillergm/orgs","repos_url":"https://api.github.com/users/ryanmillergm/repos","events_url":"https://api.github.com/users/ryanmillergm/events{/privacy}","received_events_url":"https://api.github.com/users/ryanmillergm/received_events","type":"User","site_admin":false},{"login":"n-flint","id":34421236,"node_id":"MDQ6VXNlcjM0NDIxMjM2","avatar_url":"https://avatars3.githubusercontent.com/u/34421236?v=4","gravatar_id":"","url":"https://api.github.com/users/n-flint","html_url":"https://github.com/n-flint","followers_url":"https://api.github.com/users/n-flint/followers","following_url":"https://api.github.com/users/n-flint/following{/other_user}","gists_url":"https://api.github.com/users/n-flint/gists{/gist_id}","starred_url":"https://api.github.com/users/n-flint/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/n-flint/subscriptions","organizations_url":"https://api.github.com/users/n-flint/orgs","repos_url":"https://api.github.com/users/n-flint/repos","events_url":"https://api.github.com/users/n-flint/events{/privacy}","received_events_url":"https://api.github.com/users/n-flint/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:42 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/following?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 00:12:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4992'
+      X-Ratelimit-Reset:
+      - '1562893915'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"860bc567e35e6a4bb121ca4217b7420d"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E70E:129C:1E9895:2C0427:5D27D04F
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"m-mrcr","id":28820023,"node_id":"MDQ6VXNlcjI4ODIwMDIz","avatar_url":"https://avatars3.githubusercontent.com/u/28820023?v=4","gravatar_id":"","url":"https://api.github.com/users/m-mrcr","html_url":"https://github.com/m-mrcr","followers_url":"https://api.github.com/users/m-mrcr/followers","following_url":"https://api.github.com/users/m-mrcr/following{/other_user}","gists_url":"https://api.github.com/users/m-mrcr/gists{/gist_id}","starred_url":"https://api.github.com/users/m-mrcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/m-mrcr/subscriptions","organizations_url":"https://api.github.com/users/m-mrcr/orgs","repos_url":"https://api.github.com/users/m-mrcr/repos","events_url":"https://api.github.com/users/m-mrcr/events{/privacy}","received_events_url":"https://api.github.com/users/m-mrcr/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false},{"login":"milevy1","id":36040194,"node_id":"MDQ6VXNlcjM2MDQwMTk0","avatar_url":"https://avatars3.githubusercontent.com/u/36040194?v=4","gravatar_id":"","url":"https://api.github.com/users/milevy1","html_url":"https://github.com/milevy1","followers_url":"https://api.github.com/users/milevy1/followers","following_url":"https://api.github.com/users/milevy1/following{/other_user}","gists_url":"https://api.github.com/users/milevy1/gists{/gist_id}","starred_url":"https://api.github.com/users/milevy1/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/milevy1/subscriptions","organizations_url":"https://api.github.com/users/milevy1/orgs","repos_url":"https://api.github.com/users/milevy1/repos","events_url":"https://api.github.com/users/milevy1/events{/privacy}","received_events_url":"https://api.github.com/users/milevy1/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"smainar","id":43945779,"node_id":"MDQ6VXNlcjQzOTQ1Nzc5","avatar_url":"https://avatars3.githubusercontent.com/u/43945779?v=4","gravatar_id":"","url":"https://api.github.com/users/smainar","html_url":"https://github.com/smainar","followers_url":"https://api.github.com/users/smainar/followers","following_url":"https://api.github.com/users/smainar/following{/other_user}","gists_url":"https://api.github.com/users/smainar/gists{/gist_id}","starred_url":"https://api.github.com/users/smainar/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/smainar/subscriptions","organizations_url":"https://api.github.com/users/smainar/orgs","repos_url":"https://api.github.com/users/smainar/repos","events_url":"https://api.github.com/users/smainar/events{/privacy}","received_events_url":"https://api.github.com/users/smainar/received_events","type":"User","site_admin":false},{"login":"carriewalsh","id":43975624,"node_id":"MDQ6VXNlcjQzOTc1NjI0","avatar_url":"https://avatars0.githubusercontent.com/u/43975624?v=4","gravatar_id":"","url":"https://api.github.com/users/carriewalsh","html_url":"https://github.com/carriewalsh","followers_url":"https://api.github.com/users/carriewalsh/followers","following_url":"https://api.github.com/users/carriewalsh/following{/other_user}","gists_url":"https://api.github.com/users/carriewalsh/gists{/gist_id}","starred_url":"https://api.github.com/users/carriewalsh/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/carriewalsh/subscriptions","organizations_url":"https://api.github.com/users/carriewalsh/orgs","repos_url":"https://api.github.com/users/carriewalsh/repos","events_url":"https://api.github.com/users/carriewalsh/events{/privacy}","received_events_url":"https://api.github.com/users/carriewalsh/received_events","type":"User","site_admin":false},{"login":"Loomus","id":44850604,"node_id":"MDQ6VXNlcjQ0ODUwNjA0","avatar_url":"https://avatars0.githubusercontent.com/u/44850604?v=4","gravatar_id":"","url":"https://api.github.com/users/Loomus","html_url":"https://github.com/Loomus","followers_url":"https://api.github.com/users/Loomus/followers","following_url":"https://api.github.com/users/Loomus/following{/other_user}","gists_url":"https://api.github.com/users/Loomus/gists{/gist_id}","starred_url":"https://api.github.com/users/Loomus/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Loomus/subscriptions","organizations_url":"https://api.github.com/users/Loomus/orgs","repos_url":"https://api.github.com/users/Loomus/repos","events_url":"https://api.github.com/users/Loomus/events{/privacy}","received_events_url":"https://api.github.com/users/Loomus/received_events","type":"User","site_admin":false},{"login":"james-cape","id":46202598,"node_id":"MDQ6VXNlcjQ2MjAyNTk4","avatar_url":"https://avatars2.githubusercontent.com/u/46202598?v=4","gravatar_id":"","url":"https://api.github.com/users/james-cape","html_url":"https://github.com/james-cape","followers_url":"https://api.github.com/users/james-cape/followers","following_url":"https://api.github.com/users/james-cape/following{/other_user}","gists_url":"https://api.github.com/users/james-cape/gists{/gist_id}","starred_url":"https://api.github.com/users/james-cape/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/james-cape/subscriptions","organizations_url":"https://api.github.com/users/james-cape/orgs","repos_url":"https://api.github.com/users/james-cape/repos","events_url":"https://api.github.com/users/james-cape/events{/privacy}","received_events_url":"https://api.github.com/users/james-cape/received_events","type":"User","site_admin":false},{"login":"alexander-mathieu","id":47018937,"node_id":"MDQ6VXNlcjQ3MDE4OTM3","avatar_url":"https://avatars3.githubusercontent.com/u/47018937?v=4","gravatar_id":"","url":"https://api.github.com/users/alexander-mathieu","html_url":"https://github.com/alexander-mathieu","followers_url":"https://api.github.com/users/alexander-mathieu/followers","following_url":"https://api.github.com/users/alexander-mathieu/following{/other_user}","gists_url":"https://api.github.com/users/alexander-mathieu/gists{/gist_id}","starred_url":"https://api.github.com/users/alexander-mathieu/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/alexander-mathieu/subscriptions","organizations_url":"https://api.github.com/users/alexander-mathieu/orgs","repos_url":"https://api.github.com/users/alexander-mathieu/repos","events_url":"https://api.github.com/users/alexander-mathieu/events{/privacy}","received_events_url":"https://api.github.com/users/alexander-mathieu/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:11:43 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/invite_invalid_github_handle.yml
+++ b/spec/cassettes/invite_invalid_github_handle.yml
@@ -1,0 +1,580 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=1&per_page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4952'
+      X-Ratelimit-Reset:
+      - '1562949411'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"ba9c3f3548333d08f74cd7887e36906a"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Link:
+      - <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=2&per_page=5>;
+        rel="next", <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=15&per_page=5>;
+        rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF65:468D:D3FAB7:1B4E593:5D28A913
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":194746869,"node_id":"MDEwOlJlcG9zaXRvcnkxOTQ3NDY4Njk=","name":"brownfield-of-dreams","full_name":"chakeresa/brownfield-of-dreams","private":false,"owner":{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},"html_url":"https://github.com/chakeresa/brownfield-of-dreams","description":"Rails
+        app used for hosting video tutorials and classes. Serves as the base repository
+        for a B3 project.","fork":true,"url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams","forks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/forks","keys_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/keys{/key_id}","collaborators_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/teams","hooks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/hooks","issue_events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/events{/number}","events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/events","assignees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/assignees{/user}","branches_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/branches{/branch}","tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/tags","blobs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/refs{/sha}","trees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/trees{/sha}","statuses_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/statuses/{sha}","languages_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/languages","stargazers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/stargazers","contributors_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contributors","subscribers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscribers","subscription_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscription","commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/commits{/sha}","git_commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/commits{/sha}","comments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/comments{/number}","issue_comment_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/comments{/number}","contents_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contents/{+path}","compare_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/compare/{base}...{head}","merges_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/merges","archive_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/downloads","issues_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues{/number}","pulls_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/pulls{/number}","milestones_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/milestones{/number}","notifications_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/labels{/name}","releases_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/releases{/id}","deployments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/deployments","created_at":"2019-07-01T21:43:22Z","updated_at":"2019-07-11T20:54:44Z","pushed_at":"2019-07-12T00:26:16Z","git_url":"git://github.com/chakeresa/brownfield-of-dreams.git","ssh_url":"git@github.com:chakeresa/brownfield-of-dreams.git","clone_url":"https://github.com/chakeresa/brownfield-of-dreams.git","svn_url":"https://github.com/chakeresa/brownfield-of-dreams","homepage":"","size":7756,"stargazers_count":2,"watchers_count":2,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":6,"license":null,"forks":0,"open_issues":6,"watchers":2,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":168045397,"node_id":"MDEwOlJlcG9zaXRvcnkxNjgwNDUzOTc=","name":"battleship","full_name":"jalena-penaligon/battleship","private":false,"owner":{"login":"jalena-penaligon","id":45905026,"node_id":"MDQ6VXNlcjQ1OTA1MDI2","avatar_url":"https://avatars0.githubusercontent.com/u/45905026?v=4","gravatar_id":"","url":"https://api.github.com/users/jalena-penaligon","html_url":"https://github.com/jalena-penaligon","followers_url":"https://api.github.com/users/jalena-penaligon/followers","following_url":"https://api.github.com/users/jalena-penaligon/following{/other_user}","gists_url":"https://api.github.com/users/jalena-penaligon/gists{/gist_id}","starred_url":"https://api.github.com/users/jalena-penaligon/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jalena-penaligon/subscriptions","organizations_url":"https://api.github.com/users/jalena-penaligon/orgs","repos_url":"https://api.github.com/users/jalena-penaligon/repos","events_url":"https://api.github.com/users/jalena-penaligon/events{/privacy}","received_events_url":"https://api.github.com/users/jalena-penaligon/received_events","type":"User","site_admin":false},"html_url":"https://github.com/jalena-penaligon/battleship","description":null,"fork":false,"url":"https://api.github.com/repos/jalena-penaligon/battleship","forks_url":"https://api.github.com/repos/jalena-penaligon/battleship/forks","keys_url":"https://api.github.com/repos/jalena-penaligon/battleship/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jalena-penaligon/battleship/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jalena-penaligon/battleship/teams","hooks_url":"https://api.github.com/repos/jalena-penaligon/battleship/hooks","issue_events_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/events{/number}","events_url":"https://api.github.com/repos/jalena-penaligon/battleship/events","assignees_url":"https://api.github.com/repos/jalena-penaligon/battleship/assignees{/user}","branches_url":"https://api.github.com/repos/jalena-penaligon/battleship/branches{/branch}","tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/tags","blobs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/refs{/sha}","trees_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jalena-penaligon/battleship/statuses/{sha}","languages_url":"https://api.github.com/repos/jalena-penaligon/battleship/languages","stargazers_url":"https://api.github.com/repos/jalena-penaligon/battleship/stargazers","contributors_url":"https://api.github.com/repos/jalena-penaligon/battleship/contributors","subscribers_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscribers","subscription_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscription","commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/commits{/sha}","git_commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/commits{/sha}","comments_url":"https://api.github.com/repos/jalena-penaligon/battleship/comments{/number}","issue_comment_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/comments{/number}","contents_url":"https://api.github.com/repos/jalena-penaligon/battleship/contents/{+path}","compare_url":"https://api.github.com/repos/jalena-penaligon/battleship/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jalena-penaligon/battleship/merges","archive_url":"https://api.github.com/repos/jalena-penaligon/battleship/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jalena-penaligon/battleship/downloads","issues_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues{/number}","pulls_url":"https://api.github.com/repos/jalena-penaligon/battleship/pulls{/number}","milestones_url":"https://api.github.com/repos/jalena-penaligon/battleship/milestones{/number}","notifications_url":"https://api.github.com/repos/jalena-penaligon/battleship/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jalena-penaligon/battleship/labels{/name}","releases_url":"https://api.github.com/repos/jalena-penaligon/battleship/releases{/id}","deployments_url":"https://api.github.com/repos/jalena-penaligon/battleship/deployments","created_at":"2019-01-28T22:04:39Z","updated_at":"2019-02-06T19:57:18Z","pushed_at":"2019-02-06T19:57:17Z","git_url":"git://github.com/jalena-penaligon/battleship.git","ssh_url":"git@github.com:jalena-penaligon/battleship.git","clone_url":"https://github.com/jalena-penaligon/battleship.git","svn_url":"https://github.com/jalena-penaligon/battleship","homepage":null,"size":59,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":176382436,"node_id":"MDEwOlJlcG9zaXRvcnkxNzYzODI0MzY=","name":"Battleship_project","full_name":"kylecornelissen/Battleship_project","private":false,"owner":{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},"html_url":"https://github.com/kylecornelissen/Battleship_project","description":null,"fork":false,"url":"https://api.github.com/repos/kylecornelissen/Battleship_project","forks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/forks","keys_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/keys{/key_id}","collaborators_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/teams","hooks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/hooks","issue_events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/events{/number}","events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/events","assignees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/assignees{/user}","branches_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/branches{/branch}","tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/tags","blobs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/refs{/sha}","trees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/trees{/sha}","statuses_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/statuses/{sha}","languages_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/languages","stargazers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/stargazers","contributors_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contributors","subscribers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscribers","subscription_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscription","commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/commits{/sha}","git_commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/commits{/sha}","comments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/comments{/number}","issue_comment_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/comments{/number}","contents_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contents/{+path}","compare_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/compare/{base}...{head}","merges_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/merges","archive_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/downloads","issues_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues{/number}","pulls_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/pulls{/number}","milestones_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/milestones{/number}","notifications_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/labels{/name}","releases_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/releases{/id}","deployments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/deployments","created_at":"2019-03-18T22:57:32Z","updated_at":"2019-03-28T02:16:44Z","pushed_at":"2019-03-28T02:16:43Z","git_url":"git://github.com/kylecornelissen/Battleship_project.git","ssh_url":"git@github.com:kylecornelissen/Battleship_project.git","clone_url":"https://github.com/kylecornelissen/Battleship_project.git","svn_url":"https://github.com/kylecornelissen/Battleship_project","homepage":null,"size":73,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":181714029,"node_id":"MDEwOlJlcG9zaXRvcnkxODE3MTQwMjk=","name":"1903_final","full_name":"MillsProvosty/1903_final","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/1903_final","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/1903_final","forks_url":"https://api.github.com/repos/MillsProvosty/1903_final/forks","keys_url":"https://api.github.com/repos/MillsProvosty/1903_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/1903_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/1903_final/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/1903_final/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/1903_final/events","assignees_url":"https://api.github.com/repos/MillsProvosty/1903_final/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/1903_final/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/1903_final/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/1903_final/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/1903_final/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/1903_final/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/1903_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/1903_final/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/1903_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/1903_final/merges","archive_url":"https://api.github.com/repos/MillsProvosty/1903_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/1903_final/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/1903_final/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/1903_final/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/1903_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/1903_final/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/1903_final/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/1903_final/deployments","created_at":"2019-04-16T15:11:02Z","updated_at":"2019-04-16T18:10:48Z","pushed_at":"2019-04-16T18:10:46Z","git_url":"git://github.com/MillsProvosty/1903_final.git","ssh_url":"git@github.com:MillsProvosty/1903_final.git","clone_url":"https://github.com/MillsProvosty/1903_final.git","svn_url":"https://github.com/MillsProvosty/1903_final","homepage":null,"size":8,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}},{"id":184634926,"node_id":"MDEwOlJlcG9zaXRvcnkxODQ2MzQ5MjY=","name":"activerecord-obstacle-course","full_name":"MillsProvosty/activerecord-obstacle-course","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course","forks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/forks","keys_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/events","assignees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/merges","archive_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/deployments","created_at":"2019-05-02T18:53:23Z","updated_at":"2019-05-31T17:00:15Z","pushed_at":"2019-05-31T17:00:14Z","git_url":"git://github.com/MillsProvosty/activerecord-obstacle-course.git","ssh_url":"git@github.com:MillsProvosty/activerecord-obstacle-course.git","clone_url":"https://github.com/MillsProvosty/activerecord-obstacle-course.git","svn_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","homepage":null,"size":54,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:33 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/followers?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4951'
+      X-Ratelimit-Reset:
+      - '1562949412'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"de3cc92700f1038013e3888d075e7b40"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF66:65F6:11AED30:2098692:5D28A913
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"ryanmillergm","id":42855291,"node_id":"MDQ6VXNlcjQyODU1Mjkx","avatar_url":"https://avatars0.githubusercontent.com/u/42855291?v=4","gravatar_id":"","url":"https://api.github.com/users/ryanmillergm","html_url":"https://github.com/ryanmillergm","followers_url":"https://api.github.com/users/ryanmillergm/followers","following_url":"https://api.github.com/users/ryanmillergm/following{/other_user}","gists_url":"https://api.github.com/users/ryanmillergm/gists{/gist_id}","starred_url":"https://api.github.com/users/ryanmillergm/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ryanmillergm/subscriptions","organizations_url":"https://api.github.com/users/ryanmillergm/orgs","repos_url":"https://api.github.com/users/ryanmillergm/repos","events_url":"https://api.github.com/users/ryanmillergm/events{/privacy}","received_events_url":"https://api.github.com/users/ryanmillergm/received_events","type":"User","site_admin":false},{"login":"n-flint","id":34421236,"node_id":"MDQ6VXNlcjM0NDIxMjM2","avatar_url":"https://avatars3.githubusercontent.com/u/34421236?v=4","gravatar_id":"","url":"https://api.github.com/users/n-flint","html_url":"https://github.com/n-flint","followers_url":"https://api.github.com/users/n-flint/followers","following_url":"https://api.github.com/users/n-flint/following{/other_user}","gists_url":"https://api.github.com/users/n-flint/gists{/gist_id}","starred_url":"https://api.github.com/users/n-flint/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/n-flint/subscriptions","organizations_url":"https://api.github.com/users/n-flint/orgs","repos_url":"https://api.github.com/users/n-flint/repos","events_url":"https://api.github.com/users/n-flint/events{/privacy}","received_events_url":"https://api.github.com/users/n-flint/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:33 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/following?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4950'
+      X-Ratelimit-Reset:
+      - '1562949412'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"860bc567e35e6a4bb121ca4217b7420d"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF6B:6B89:1093857:1F46D1C:5D28A914
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"m-mrcr","id":28820023,"node_id":"MDQ6VXNlcjI4ODIwMDIz","avatar_url":"https://avatars3.githubusercontent.com/u/28820023?v=4","gravatar_id":"","url":"https://api.github.com/users/m-mrcr","html_url":"https://github.com/m-mrcr","followers_url":"https://api.github.com/users/m-mrcr/followers","following_url":"https://api.github.com/users/m-mrcr/following{/other_user}","gists_url":"https://api.github.com/users/m-mrcr/gists{/gist_id}","starred_url":"https://api.github.com/users/m-mrcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/m-mrcr/subscriptions","organizations_url":"https://api.github.com/users/m-mrcr/orgs","repos_url":"https://api.github.com/users/m-mrcr/repos","events_url":"https://api.github.com/users/m-mrcr/events{/privacy}","received_events_url":"https://api.github.com/users/m-mrcr/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false},{"login":"milevy1","id":36040194,"node_id":"MDQ6VXNlcjM2MDQwMTk0","avatar_url":"https://avatars3.githubusercontent.com/u/36040194?v=4","gravatar_id":"","url":"https://api.github.com/users/milevy1","html_url":"https://github.com/milevy1","followers_url":"https://api.github.com/users/milevy1/followers","following_url":"https://api.github.com/users/milevy1/following{/other_user}","gists_url":"https://api.github.com/users/milevy1/gists{/gist_id}","starred_url":"https://api.github.com/users/milevy1/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/milevy1/subscriptions","organizations_url":"https://api.github.com/users/milevy1/orgs","repos_url":"https://api.github.com/users/milevy1/repos","events_url":"https://api.github.com/users/milevy1/events{/privacy}","received_events_url":"https://api.github.com/users/milevy1/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"smainar","id":43945779,"node_id":"MDQ6VXNlcjQzOTQ1Nzc5","avatar_url":"https://avatars3.githubusercontent.com/u/43945779?v=4","gravatar_id":"","url":"https://api.github.com/users/smainar","html_url":"https://github.com/smainar","followers_url":"https://api.github.com/users/smainar/followers","following_url":"https://api.github.com/users/smainar/following{/other_user}","gists_url":"https://api.github.com/users/smainar/gists{/gist_id}","starred_url":"https://api.github.com/users/smainar/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/smainar/subscriptions","organizations_url":"https://api.github.com/users/smainar/orgs","repos_url":"https://api.github.com/users/smainar/repos","events_url":"https://api.github.com/users/smainar/events{/privacy}","received_events_url":"https://api.github.com/users/smainar/received_events","type":"User","site_admin":false},{"login":"carriewalsh","id":43975624,"node_id":"MDQ6VXNlcjQzOTc1NjI0","avatar_url":"https://avatars0.githubusercontent.com/u/43975624?v=4","gravatar_id":"","url":"https://api.github.com/users/carriewalsh","html_url":"https://github.com/carriewalsh","followers_url":"https://api.github.com/users/carriewalsh/followers","following_url":"https://api.github.com/users/carriewalsh/following{/other_user}","gists_url":"https://api.github.com/users/carriewalsh/gists{/gist_id}","starred_url":"https://api.github.com/users/carriewalsh/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/carriewalsh/subscriptions","organizations_url":"https://api.github.com/users/carriewalsh/orgs","repos_url":"https://api.github.com/users/carriewalsh/repos","events_url":"https://api.github.com/users/carriewalsh/events{/privacy}","received_events_url":"https://api.github.com/users/carriewalsh/received_events","type":"User","site_admin":false},{"login":"Loomus","id":44850604,"node_id":"MDQ6VXNlcjQ0ODUwNjA0","avatar_url":"https://avatars0.githubusercontent.com/u/44850604?v=4","gravatar_id":"","url":"https://api.github.com/users/Loomus","html_url":"https://github.com/Loomus","followers_url":"https://api.github.com/users/Loomus/followers","following_url":"https://api.github.com/users/Loomus/following{/other_user}","gists_url":"https://api.github.com/users/Loomus/gists{/gist_id}","starred_url":"https://api.github.com/users/Loomus/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Loomus/subscriptions","organizations_url":"https://api.github.com/users/Loomus/orgs","repos_url":"https://api.github.com/users/Loomus/repos","events_url":"https://api.github.com/users/Loomus/events{/privacy}","received_events_url":"https://api.github.com/users/Loomus/received_events","type":"User","site_admin":false},{"login":"james-cape","id":46202598,"node_id":"MDQ6VXNlcjQ2MjAyNTk4","avatar_url":"https://avatars2.githubusercontent.com/u/46202598?v=4","gravatar_id":"","url":"https://api.github.com/users/james-cape","html_url":"https://github.com/james-cape","followers_url":"https://api.github.com/users/james-cape/followers","following_url":"https://api.github.com/users/james-cape/following{/other_user}","gists_url":"https://api.github.com/users/james-cape/gists{/gist_id}","starred_url":"https://api.github.com/users/james-cape/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/james-cape/subscriptions","organizations_url":"https://api.github.com/users/james-cape/orgs","repos_url":"https://api.github.com/users/james-cape/repos","events_url":"https://api.github.com/users/james-cape/events{/privacy}","received_events_url":"https://api.github.com/users/james-cape/received_events","type":"User","site_admin":false},{"login":"alexander-mathieu","id":47018937,"node_id":"MDQ6VXNlcjQ3MDE4OTM3","avatar_url":"https://avatars3.githubusercontent.com/u/47018937?v=4","gravatar_id":"","url":"https://api.github.com/users/alexander-mathieu","html_url":"https://github.com/alexander-mathieu","followers_url":"https://api.github.com/users/alexander-mathieu/followers","following_url":"https://api.github.com/users/alexander-mathieu/following{/other_user}","gists_url":"https://api.github.com/users/alexander-mathieu/gists{/gist_id}","starred_url":"https://api.github.com/users/alexander-mathieu/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/alexander-mathieu/subscriptions","organizations_url":"https://api.github.com/users/alexander-mathieu/orgs","repos_url":"https://api.github.com/users/alexander-mathieu/repos","events_url":"https://api.github.com/users/alexander-mathieu/events{/privacy}","received_events_url":"https://api.github.com/users/alexander-mathieu/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:33 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4949'
+      X-Ratelimit-Reset:
+      - '1562949414'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF74:4899:CB3177:1A7CCAA:5D28A916
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:36 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty111?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 404 Not Found
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4948'
+      X-Ratelimit-Reset:
+      - '1562949415'
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF75:423F:762CFB:1196D52:5D28A916
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/users/#get-a-single-user"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:36 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=1&per_page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4947'
+      X-Ratelimit-Reset:
+      - '1562949415'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"ba9c3f3548333d08f74cd7887e36906a"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Link:
+      - <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=2&per_page=5>;
+        rel="next", <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=15&per_page=5>;
+        rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF7A:440E:FFF059:1E24360:5D28A917
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":194746869,"node_id":"MDEwOlJlcG9zaXRvcnkxOTQ3NDY4Njk=","name":"brownfield-of-dreams","full_name":"chakeresa/brownfield-of-dreams","private":false,"owner":{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},"html_url":"https://github.com/chakeresa/brownfield-of-dreams","description":"Rails
+        app used for hosting video tutorials and classes. Serves as the base repository
+        for a B3 project.","fork":true,"url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams","forks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/forks","keys_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/keys{/key_id}","collaborators_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/teams","hooks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/hooks","issue_events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/events{/number}","events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/events","assignees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/assignees{/user}","branches_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/branches{/branch}","tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/tags","blobs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/refs{/sha}","trees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/trees{/sha}","statuses_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/statuses/{sha}","languages_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/languages","stargazers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/stargazers","contributors_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contributors","subscribers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscribers","subscription_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscription","commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/commits{/sha}","git_commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/commits{/sha}","comments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/comments{/number}","issue_comment_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/comments{/number}","contents_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contents/{+path}","compare_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/compare/{base}...{head}","merges_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/merges","archive_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/downloads","issues_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues{/number}","pulls_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/pulls{/number}","milestones_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/milestones{/number}","notifications_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/labels{/name}","releases_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/releases{/id}","deployments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/deployments","created_at":"2019-07-01T21:43:22Z","updated_at":"2019-07-11T20:54:44Z","pushed_at":"2019-07-12T00:26:16Z","git_url":"git://github.com/chakeresa/brownfield-of-dreams.git","ssh_url":"git@github.com:chakeresa/brownfield-of-dreams.git","clone_url":"https://github.com/chakeresa/brownfield-of-dreams.git","svn_url":"https://github.com/chakeresa/brownfield-of-dreams","homepage":"","size":7756,"stargazers_count":2,"watchers_count":2,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":6,"license":null,"forks":0,"open_issues":6,"watchers":2,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":168045397,"node_id":"MDEwOlJlcG9zaXRvcnkxNjgwNDUzOTc=","name":"battleship","full_name":"jalena-penaligon/battleship","private":false,"owner":{"login":"jalena-penaligon","id":45905026,"node_id":"MDQ6VXNlcjQ1OTA1MDI2","avatar_url":"https://avatars0.githubusercontent.com/u/45905026?v=4","gravatar_id":"","url":"https://api.github.com/users/jalena-penaligon","html_url":"https://github.com/jalena-penaligon","followers_url":"https://api.github.com/users/jalena-penaligon/followers","following_url":"https://api.github.com/users/jalena-penaligon/following{/other_user}","gists_url":"https://api.github.com/users/jalena-penaligon/gists{/gist_id}","starred_url":"https://api.github.com/users/jalena-penaligon/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jalena-penaligon/subscriptions","organizations_url":"https://api.github.com/users/jalena-penaligon/orgs","repos_url":"https://api.github.com/users/jalena-penaligon/repos","events_url":"https://api.github.com/users/jalena-penaligon/events{/privacy}","received_events_url":"https://api.github.com/users/jalena-penaligon/received_events","type":"User","site_admin":false},"html_url":"https://github.com/jalena-penaligon/battleship","description":null,"fork":false,"url":"https://api.github.com/repos/jalena-penaligon/battleship","forks_url":"https://api.github.com/repos/jalena-penaligon/battleship/forks","keys_url":"https://api.github.com/repos/jalena-penaligon/battleship/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jalena-penaligon/battleship/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jalena-penaligon/battleship/teams","hooks_url":"https://api.github.com/repos/jalena-penaligon/battleship/hooks","issue_events_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/events{/number}","events_url":"https://api.github.com/repos/jalena-penaligon/battleship/events","assignees_url":"https://api.github.com/repos/jalena-penaligon/battleship/assignees{/user}","branches_url":"https://api.github.com/repos/jalena-penaligon/battleship/branches{/branch}","tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/tags","blobs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/refs{/sha}","trees_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jalena-penaligon/battleship/statuses/{sha}","languages_url":"https://api.github.com/repos/jalena-penaligon/battleship/languages","stargazers_url":"https://api.github.com/repos/jalena-penaligon/battleship/stargazers","contributors_url":"https://api.github.com/repos/jalena-penaligon/battleship/contributors","subscribers_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscribers","subscription_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscription","commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/commits{/sha}","git_commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/commits{/sha}","comments_url":"https://api.github.com/repos/jalena-penaligon/battleship/comments{/number}","issue_comment_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/comments{/number}","contents_url":"https://api.github.com/repos/jalena-penaligon/battleship/contents/{+path}","compare_url":"https://api.github.com/repos/jalena-penaligon/battleship/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jalena-penaligon/battleship/merges","archive_url":"https://api.github.com/repos/jalena-penaligon/battleship/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jalena-penaligon/battleship/downloads","issues_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues{/number}","pulls_url":"https://api.github.com/repos/jalena-penaligon/battleship/pulls{/number}","milestones_url":"https://api.github.com/repos/jalena-penaligon/battleship/milestones{/number}","notifications_url":"https://api.github.com/repos/jalena-penaligon/battleship/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jalena-penaligon/battleship/labels{/name}","releases_url":"https://api.github.com/repos/jalena-penaligon/battleship/releases{/id}","deployments_url":"https://api.github.com/repos/jalena-penaligon/battleship/deployments","created_at":"2019-01-28T22:04:39Z","updated_at":"2019-02-06T19:57:18Z","pushed_at":"2019-02-06T19:57:17Z","git_url":"git://github.com/jalena-penaligon/battleship.git","ssh_url":"git@github.com:jalena-penaligon/battleship.git","clone_url":"https://github.com/jalena-penaligon/battleship.git","svn_url":"https://github.com/jalena-penaligon/battleship","homepage":null,"size":59,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":176382436,"node_id":"MDEwOlJlcG9zaXRvcnkxNzYzODI0MzY=","name":"Battleship_project","full_name":"kylecornelissen/Battleship_project","private":false,"owner":{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},"html_url":"https://github.com/kylecornelissen/Battleship_project","description":null,"fork":false,"url":"https://api.github.com/repos/kylecornelissen/Battleship_project","forks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/forks","keys_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/keys{/key_id}","collaborators_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/teams","hooks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/hooks","issue_events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/events{/number}","events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/events","assignees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/assignees{/user}","branches_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/branches{/branch}","tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/tags","blobs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/refs{/sha}","trees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/trees{/sha}","statuses_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/statuses/{sha}","languages_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/languages","stargazers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/stargazers","contributors_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contributors","subscribers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscribers","subscription_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscription","commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/commits{/sha}","git_commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/commits{/sha}","comments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/comments{/number}","issue_comment_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/comments{/number}","contents_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contents/{+path}","compare_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/compare/{base}...{head}","merges_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/merges","archive_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/downloads","issues_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues{/number}","pulls_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/pulls{/number}","milestones_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/milestones{/number}","notifications_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/labels{/name}","releases_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/releases{/id}","deployments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/deployments","created_at":"2019-03-18T22:57:32Z","updated_at":"2019-03-28T02:16:44Z","pushed_at":"2019-03-28T02:16:43Z","git_url":"git://github.com/kylecornelissen/Battleship_project.git","ssh_url":"git@github.com:kylecornelissen/Battleship_project.git","clone_url":"https://github.com/kylecornelissen/Battleship_project.git","svn_url":"https://github.com/kylecornelissen/Battleship_project","homepage":null,"size":73,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":181714029,"node_id":"MDEwOlJlcG9zaXRvcnkxODE3MTQwMjk=","name":"1903_final","full_name":"MillsProvosty/1903_final","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/1903_final","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/1903_final","forks_url":"https://api.github.com/repos/MillsProvosty/1903_final/forks","keys_url":"https://api.github.com/repos/MillsProvosty/1903_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/1903_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/1903_final/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/1903_final/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/1903_final/events","assignees_url":"https://api.github.com/repos/MillsProvosty/1903_final/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/1903_final/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/1903_final/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/1903_final/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/1903_final/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/1903_final/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/1903_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/1903_final/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/1903_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/1903_final/merges","archive_url":"https://api.github.com/repos/MillsProvosty/1903_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/1903_final/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/1903_final/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/1903_final/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/1903_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/1903_final/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/1903_final/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/1903_final/deployments","created_at":"2019-04-16T15:11:02Z","updated_at":"2019-04-16T18:10:48Z","pushed_at":"2019-04-16T18:10:46Z","git_url":"git://github.com/MillsProvosty/1903_final.git","ssh_url":"git@github.com:MillsProvosty/1903_final.git","clone_url":"https://github.com/MillsProvosty/1903_final.git","svn_url":"https://github.com/MillsProvosty/1903_final","homepage":null,"size":8,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}},{"id":184634926,"node_id":"MDEwOlJlcG9zaXRvcnkxODQ2MzQ5MjY=","name":"activerecord-obstacle-course","full_name":"MillsProvosty/activerecord-obstacle-course","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course","forks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/forks","keys_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/events","assignees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/merges","archive_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/deployments","created_at":"2019-05-02T18:53:23Z","updated_at":"2019-05-31T17:00:15Z","pushed_at":"2019-05-31T17:00:14Z","git_url":"git://github.com/MillsProvosty/activerecord-obstacle-course.git","ssh_url":"git@github.com:MillsProvosty/activerecord-obstacle-course.git","clone_url":"https://github.com/MillsProvosty/activerecord-obstacle-course.git","svn_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","homepage":null,"size":54,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:37 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/followers?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4946'
+      X-Ratelimit-Reset:
+      - '1562949415'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"de3cc92700f1038013e3888d075e7b40"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF7B:7C8A:10ACEBC:1F1146F:5D28A917
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"ryanmillergm","id":42855291,"node_id":"MDQ6VXNlcjQyODU1Mjkx","avatar_url":"https://avatars0.githubusercontent.com/u/42855291?v=4","gravatar_id":"","url":"https://api.github.com/users/ryanmillergm","html_url":"https://github.com/ryanmillergm","followers_url":"https://api.github.com/users/ryanmillergm/followers","following_url":"https://api.github.com/users/ryanmillergm/following{/other_user}","gists_url":"https://api.github.com/users/ryanmillergm/gists{/gist_id}","starred_url":"https://api.github.com/users/ryanmillergm/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ryanmillergm/subscriptions","organizations_url":"https://api.github.com/users/ryanmillergm/orgs","repos_url":"https://api.github.com/users/ryanmillergm/repos","events_url":"https://api.github.com/users/ryanmillergm/events{/privacy}","received_events_url":"https://api.github.com/users/ryanmillergm/received_events","type":"User","site_admin":false},{"login":"n-flint","id":34421236,"node_id":"MDQ6VXNlcjM0NDIxMjM2","avatar_url":"https://avatars3.githubusercontent.com/u/34421236?v=4","gravatar_id":"","url":"https://api.github.com/users/n-flint","html_url":"https://github.com/n-flint","followers_url":"https://api.github.com/users/n-flint/followers","following_url":"https://api.github.com/users/n-flint/following{/other_user}","gists_url":"https://api.github.com/users/n-flint/gists{/gist_id}","starred_url":"https://api.github.com/users/n-flint/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/n-flint/subscriptions","organizations_url":"https://api.github.com/users/n-flint/orgs","repos_url":"https://api.github.com/users/n-flint/repos","events_url":"https://api.github.com/users/n-flint/events{/privacy}","received_events_url":"https://api.github.com/users/n-flint/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:37 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/following?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 15:36:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4945'
+      X-Ratelimit-Reset:
+      - '1562949416'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"860bc567e35e6a4bb121ca4217b7420d"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF7C:0632:78646A:1236D59:5D28A918
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"m-mrcr","id":28820023,"node_id":"MDQ6VXNlcjI4ODIwMDIz","avatar_url":"https://avatars3.githubusercontent.com/u/28820023?v=4","gravatar_id":"","url":"https://api.github.com/users/m-mrcr","html_url":"https://github.com/m-mrcr","followers_url":"https://api.github.com/users/m-mrcr/followers","following_url":"https://api.github.com/users/m-mrcr/following{/other_user}","gists_url":"https://api.github.com/users/m-mrcr/gists{/gist_id}","starred_url":"https://api.github.com/users/m-mrcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/m-mrcr/subscriptions","organizations_url":"https://api.github.com/users/m-mrcr/orgs","repos_url":"https://api.github.com/users/m-mrcr/repos","events_url":"https://api.github.com/users/m-mrcr/events{/privacy}","received_events_url":"https://api.github.com/users/m-mrcr/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false},{"login":"milevy1","id":36040194,"node_id":"MDQ6VXNlcjM2MDQwMTk0","avatar_url":"https://avatars3.githubusercontent.com/u/36040194?v=4","gravatar_id":"","url":"https://api.github.com/users/milevy1","html_url":"https://github.com/milevy1","followers_url":"https://api.github.com/users/milevy1/followers","following_url":"https://api.github.com/users/milevy1/following{/other_user}","gists_url":"https://api.github.com/users/milevy1/gists{/gist_id}","starred_url":"https://api.github.com/users/milevy1/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/milevy1/subscriptions","organizations_url":"https://api.github.com/users/milevy1/orgs","repos_url":"https://api.github.com/users/milevy1/repos","events_url":"https://api.github.com/users/milevy1/events{/privacy}","received_events_url":"https://api.github.com/users/milevy1/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"smainar","id":43945779,"node_id":"MDQ6VXNlcjQzOTQ1Nzc5","avatar_url":"https://avatars3.githubusercontent.com/u/43945779?v=4","gravatar_id":"","url":"https://api.github.com/users/smainar","html_url":"https://github.com/smainar","followers_url":"https://api.github.com/users/smainar/followers","following_url":"https://api.github.com/users/smainar/following{/other_user}","gists_url":"https://api.github.com/users/smainar/gists{/gist_id}","starred_url":"https://api.github.com/users/smainar/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/smainar/subscriptions","organizations_url":"https://api.github.com/users/smainar/orgs","repos_url":"https://api.github.com/users/smainar/repos","events_url":"https://api.github.com/users/smainar/events{/privacy}","received_events_url":"https://api.github.com/users/smainar/received_events","type":"User","site_admin":false},{"login":"carriewalsh","id":43975624,"node_id":"MDQ6VXNlcjQzOTc1NjI0","avatar_url":"https://avatars0.githubusercontent.com/u/43975624?v=4","gravatar_id":"","url":"https://api.github.com/users/carriewalsh","html_url":"https://github.com/carriewalsh","followers_url":"https://api.github.com/users/carriewalsh/followers","following_url":"https://api.github.com/users/carriewalsh/following{/other_user}","gists_url":"https://api.github.com/users/carriewalsh/gists{/gist_id}","starred_url":"https://api.github.com/users/carriewalsh/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/carriewalsh/subscriptions","organizations_url":"https://api.github.com/users/carriewalsh/orgs","repos_url":"https://api.github.com/users/carriewalsh/repos","events_url":"https://api.github.com/users/carriewalsh/events{/privacy}","received_events_url":"https://api.github.com/users/carriewalsh/received_events","type":"User","site_admin":false},{"login":"Loomus","id":44850604,"node_id":"MDQ6VXNlcjQ0ODUwNjA0","avatar_url":"https://avatars0.githubusercontent.com/u/44850604?v=4","gravatar_id":"","url":"https://api.github.com/users/Loomus","html_url":"https://github.com/Loomus","followers_url":"https://api.github.com/users/Loomus/followers","following_url":"https://api.github.com/users/Loomus/following{/other_user}","gists_url":"https://api.github.com/users/Loomus/gists{/gist_id}","starred_url":"https://api.github.com/users/Loomus/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Loomus/subscriptions","organizations_url":"https://api.github.com/users/Loomus/orgs","repos_url":"https://api.github.com/users/Loomus/repos","events_url":"https://api.github.com/users/Loomus/events{/privacy}","received_events_url":"https://api.github.com/users/Loomus/received_events","type":"User","site_admin":false},{"login":"james-cape","id":46202598,"node_id":"MDQ6VXNlcjQ2MjAyNTk4","avatar_url":"https://avatars2.githubusercontent.com/u/46202598?v=4","gravatar_id":"","url":"https://api.github.com/users/james-cape","html_url":"https://github.com/james-cape","followers_url":"https://api.github.com/users/james-cape/followers","following_url":"https://api.github.com/users/james-cape/following{/other_user}","gists_url":"https://api.github.com/users/james-cape/gists{/gist_id}","starred_url":"https://api.github.com/users/james-cape/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/james-cape/subscriptions","organizations_url":"https://api.github.com/users/james-cape/orgs","repos_url":"https://api.github.com/users/james-cape/repos","events_url":"https://api.github.com/users/james-cape/events{/privacy}","received_events_url":"https://api.github.com/users/james-cape/received_events","type":"User","site_admin":false},{"login":"alexander-mathieu","id":47018937,"node_id":"MDQ6VXNlcjQ3MDE4OTM3","avatar_url":"https://avatars3.githubusercontent.com/u/47018937?v=4","gravatar_id":"","url":"https://api.github.com/users/alexander-mathieu","html_url":"https://github.com/alexander-mathieu","followers_url":"https://api.github.com/users/alexander-mathieu/followers","following_url":"https://api.github.com/users/alexander-mathieu/following{/other_user}","gists_url":"https://api.github.com/users/alexander-mathieu/gists{/gist_id}","starred_url":"https://api.github.com/users/alexander-mathieu/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/alexander-mathieu/subscriptions","organizations_url":"https://api.github.com/users/alexander-mathieu/orgs","repos_url":"https://api.github.com/users/alexander-mathieu/repos","events_url":"https://api.github.com/users/alexander-mathieu/events{/privacy}","received_events_url":"https://api.github.com/users/alexander-mathieu/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:36:37 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/invite_maker_github_handle_with_private_email.yml
+++ b/spec/cassettes/invite_maker_github_handle_with_private_email.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 22:16:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4997'
+      X-Ratelimit-Reset:
+      - '1562973407'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E8F7:7471:3EAF40:5CF9D1:5D2906D1
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 22:16:30 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 22:16:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4996'
+      X-Ratelimit-Reset:
+      - '1562973407'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E8FC:7471:3EAF46:5CF9D7:5D2906D1
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 22:16:30 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/invite_maker_invalid_github_handle.yml
+++ b/spec/cassettes/invite_maker_invalid_github_handle.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 22:16:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4995'
+      X-Ratelimit-Reset:
+      - '1562973407'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E901:3CA5:130625:1BF310:5D2906D3
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 22:16:32 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty1111?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 22:16:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4994'
+      X-Ratelimit-Reset:
+      - '1562973407'
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E906:4B07:585E7E:82D309:5D2906D3
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/users/#get-a-single-user"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 22:16:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/invite_maker_valid_github_handle.yml
+++ b/spec/cassettes/invite_maker_valid_github_handle.yml
@@ -1,0 +1,155 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 22:16:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4999'
+      X-Ratelimit-Reset:
+      - '1562973407'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E8EC:5BAD:F6DA9:15D80A:5D2906CE
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 22:16:27 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/chakeresa?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jul 2019 22:16:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4998'
+      X-Ratelimit-Reset:
+      - '1562973407'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      Etag:
+      - W/"cf041d49c113ecc7bac9882ecd61e228"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:25:54 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - E8F1:4CD1:C7C8B:120E85:5D2906CF
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false,"name":"Alexandra
+        Chakeres","company":null,"blog":"https://www.linkedin.com/in/alexandrachakeres/","location":"Denver,
+        CO","email":"alexchakeres@gmail.com","hireable":null,"bio":"Back End Engineering
+        student at Turing School of Software & Design","public_repos":45,"public_gists":3,"followers":4,"following":1,"created_at":"2019-02-04T02:41:16Z","updated_at":"2019-07-11T23:25:54Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 22:16:28 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/invite_private_github_user.yml
+++ b/spec/cassettes/invite_private_github_user.yml
@@ -1,0 +1,590 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=1&per_page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4942'
+      X-Ratelimit-Reset:
+      - '1562894714'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"2cb8a82e98751c79d91daec999a32378"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Link:
+      - <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=2&per_page=5>;
+        rel="next", <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=15&per_page=5>;
+        rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4D6:01B3:AA9A39:14501DD:5D27D36A
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":194746869,"node_id":"MDEwOlJlcG9zaXRvcnkxOTQ3NDY4Njk=","name":"brownfield-of-dreams","full_name":"chakeresa/brownfield-of-dreams","private":false,"owner":{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},"html_url":"https://github.com/chakeresa/brownfield-of-dreams","description":"Rails
+        app used for hosting video tutorials and classes. Serves as the base repository
+        for a B3 project.","fork":true,"url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams","forks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/forks","keys_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/keys{/key_id}","collaborators_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/teams","hooks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/hooks","issue_events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/events{/number}","events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/events","assignees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/assignees{/user}","branches_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/branches{/branch}","tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/tags","blobs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/refs{/sha}","trees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/trees{/sha}","statuses_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/statuses/{sha}","languages_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/languages","stargazers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/stargazers","contributors_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contributors","subscribers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscribers","subscription_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscription","commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/commits{/sha}","git_commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/commits{/sha}","comments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/comments{/number}","issue_comment_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/comments{/number}","contents_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contents/{+path}","compare_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/compare/{base}...{head}","merges_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/merges","archive_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/downloads","issues_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues{/number}","pulls_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/pulls{/number}","milestones_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/milestones{/number}","notifications_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/labels{/name}","releases_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/releases{/id}","deployments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/deployments","created_at":"2019-07-01T21:43:22Z","updated_at":"2019-07-11T20:54:44Z","pushed_at":"2019-07-12T00:01:23Z","git_url":"git://github.com/chakeresa/brownfield-of-dreams.git","ssh_url":"git@github.com:chakeresa/brownfield-of-dreams.git","clone_url":"https://github.com/chakeresa/brownfield-of-dreams.git","svn_url":"https://github.com/chakeresa/brownfield-of-dreams","homepage":"","size":7735,"stargazers_count":2,"watchers_count":2,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":6,"license":null,"forks":0,"open_issues":6,"watchers":2,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":168045397,"node_id":"MDEwOlJlcG9zaXRvcnkxNjgwNDUzOTc=","name":"battleship","full_name":"jalena-penaligon/battleship","private":false,"owner":{"login":"jalena-penaligon","id":45905026,"node_id":"MDQ6VXNlcjQ1OTA1MDI2","avatar_url":"https://avatars0.githubusercontent.com/u/45905026?v=4","gravatar_id":"","url":"https://api.github.com/users/jalena-penaligon","html_url":"https://github.com/jalena-penaligon","followers_url":"https://api.github.com/users/jalena-penaligon/followers","following_url":"https://api.github.com/users/jalena-penaligon/following{/other_user}","gists_url":"https://api.github.com/users/jalena-penaligon/gists{/gist_id}","starred_url":"https://api.github.com/users/jalena-penaligon/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jalena-penaligon/subscriptions","organizations_url":"https://api.github.com/users/jalena-penaligon/orgs","repos_url":"https://api.github.com/users/jalena-penaligon/repos","events_url":"https://api.github.com/users/jalena-penaligon/events{/privacy}","received_events_url":"https://api.github.com/users/jalena-penaligon/received_events","type":"User","site_admin":false},"html_url":"https://github.com/jalena-penaligon/battleship","description":null,"fork":false,"url":"https://api.github.com/repos/jalena-penaligon/battleship","forks_url":"https://api.github.com/repos/jalena-penaligon/battleship/forks","keys_url":"https://api.github.com/repos/jalena-penaligon/battleship/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jalena-penaligon/battleship/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jalena-penaligon/battleship/teams","hooks_url":"https://api.github.com/repos/jalena-penaligon/battleship/hooks","issue_events_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/events{/number}","events_url":"https://api.github.com/repos/jalena-penaligon/battleship/events","assignees_url":"https://api.github.com/repos/jalena-penaligon/battleship/assignees{/user}","branches_url":"https://api.github.com/repos/jalena-penaligon/battleship/branches{/branch}","tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/tags","blobs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/refs{/sha}","trees_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jalena-penaligon/battleship/statuses/{sha}","languages_url":"https://api.github.com/repos/jalena-penaligon/battleship/languages","stargazers_url":"https://api.github.com/repos/jalena-penaligon/battleship/stargazers","contributors_url":"https://api.github.com/repos/jalena-penaligon/battleship/contributors","subscribers_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscribers","subscription_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscription","commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/commits{/sha}","git_commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/commits{/sha}","comments_url":"https://api.github.com/repos/jalena-penaligon/battleship/comments{/number}","issue_comment_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/comments{/number}","contents_url":"https://api.github.com/repos/jalena-penaligon/battleship/contents/{+path}","compare_url":"https://api.github.com/repos/jalena-penaligon/battleship/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jalena-penaligon/battleship/merges","archive_url":"https://api.github.com/repos/jalena-penaligon/battleship/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jalena-penaligon/battleship/downloads","issues_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues{/number}","pulls_url":"https://api.github.com/repos/jalena-penaligon/battleship/pulls{/number}","milestones_url":"https://api.github.com/repos/jalena-penaligon/battleship/milestones{/number}","notifications_url":"https://api.github.com/repos/jalena-penaligon/battleship/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jalena-penaligon/battleship/labels{/name}","releases_url":"https://api.github.com/repos/jalena-penaligon/battleship/releases{/id}","deployments_url":"https://api.github.com/repos/jalena-penaligon/battleship/deployments","created_at":"2019-01-28T22:04:39Z","updated_at":"2019-02-06T19:57:18Z","pushed_at":"2019-02-06T19:57:17Z","git_url":"git://github.com/jalena-penaligon/battleship.git","ssh_url":"git@github.com:jalena-penaligon/battleship.git","clone_url":"https://github.com/jalena-penaligon/battleship.git","svn_url":"https://github.com/jalena-penaligon/battleship","homepage":null,"size":59,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":176382436,"node_id":"MDEwOlJlcG9zaXRvcnkxNzYzODI0MzY=","name":"Battleship_project","full_name":"kylecornelissen/Battleship_project","private":false,"owner":{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},"html_url":"https://github.com/kylecornelissen/Battleship_project","description":null,"fork":false,"url":"https://api.github.com/repos/kylecornelissen/Battleship_project","forks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/forks","keys_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/keys{/key_id}","collaborators_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/teams","hooks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/hooks","issue_events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/events{/number}","events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/events","assignees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/assignees{/user}","branches_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/branches{/branch}","tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/tags","blobs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/refs{/sha}","trees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/trees{/sha}","statuses_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/statuses/{sha}","languages_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/languages","stargazers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/stargazers","contributors_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contributors","subscribers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscribers","subscription_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscription","commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/commits{/sha}","git_commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/commits{/sha}","comments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/comments{/number}","issue_comment_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/comments{/number}","contents_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contents/{+path}","compare_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/compare/{base}...{head}","merges_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/merges","archive_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/downloads","issues_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues{/number}","pulls_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/pulls{/number}","milestones_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/milestones{/number}","notifications_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/labels{/name}","releases_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/releases{/id}","deployments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/deployments","created_at":"2019-03-18T22:57:32Z","updated_at":"2019-03-28T02:16:44Z","pushed_at":"2019-03-28T02:16:43Z","git_url":"git://github.com/kylecornelissen/Battleship_project.git","ssh_url":"git@github.com:kylecornelissen/Battleship_project.git","clone_url":"https://github.com/kylecornelissen/Battleship_project.git","svn_url":"https://github.com/kylecornelissen/Battleship_project","homepage":null,"size":73,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":181714029,"node_id":"MDEwOlJlcG9zaXRvcnkxODE3MTQwMjk=","name":"1903_final","full_name":"MillsProvosty/1903_final","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/1903_final","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/1903_final","forks_url":"https://api.github.com/repos/MillsProvosty/1903_final/forks","keys_url":"https://api.github.com/repos/MillsProvosty/1903_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/1903_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/1903_final/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/1903_final/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/1903_final/events","assignees_url":"https://api.github.com/repos/MillsProvosty/1903_final/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/1903_final/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/1903_final/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/1903_final/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/1903_final/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/1903_final/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/1903_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/1903_final/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/1903_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/1903_final/merges","archive_url":"https://api.github.com/repos/MillsProvosty/1903_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/1903_final/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/1903_final/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/1903_final/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/1903_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/1903_final/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/1903_final/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/1903_final/deployments","created_at":"2019-04-16T15:11:02Z","updated_at":"2019-04-16T18:10:48Z","pushed_at":"2019-04-16T18:10:46Z","git_url":"git://github.com/MillsProvosty/1903_final.git","ssh_url":"git@github.com:MillsProvosty/1903_final.git","clone_url":"https://github.com/MillsProvosty/1903_final.git","svn_url":"https://github.com/MillsProvosty/1903_final","homepage":null,"size":8,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}},{"id":184634926,"node_id":"MDEwOlJlcG9zaXRvcnkxODQ2MzQ5MjY=","name":"activerecord-obstacle-course","full_name":"MillsProvosty/activerecord-obstacle-course","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course","forks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/forks","keys_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/events","assignees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/merges","archive_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/deployments","created_at":"2019-05-02T18:53:23Z","updated_at":"2019-05-31T17:00:15Z","pushed_at":"2019-05-31T17:00:14Z","git_url":"git://github.com/MillsProvosty/activerecord-obstacle-course.git","ssh_url":"git@github.com:MillsProvosty/activerecord-obstacle-course.git","clone_url":"https://github.com/MillsProvosty/activerecord-obstacle-course.git","svn_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","homepage":null,"size":54,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:24:57 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/followers?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4941'
+      X-Ratelimit-Reset:
+      - '1562894715'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"de3cc92700f1038013e3888d075e7b40"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4D7:5E96:B12118:14CAE45:5D27D36A
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"ryanmillergm","id":42855291,"node_id":"MDQ6VXNlcjQyODU1Mjkx","avatar_url":"https://avatars0.githubusercontent.com/u/42855291?v=4","gravatar_id":"","url":"https://api.github.com/users/ryanmillergm","html_url":"https://github.com/ryanmillergm","followers_url":"https://api.github.com/users/ryanmillergm/followers","following_url":"https://api.github.com/users/ryanmillergm/following{/other_user}","gists_url":"https://api.github.com/users/ryanmillergm/gists{/gist_id}","starred_url":"https://api.github.com/users/ryanmillergm/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ryanmillergm/subscriptions","organizations_url":"https://api.github.com/users/ryanmillergm/orgs","repos_url":"https://api.github.com/users/ryanmillergm/repos","events_url":"https://api.github.com/users/ryanmillergm/events{/privacy}","received_events_url":"https://api.github.com/users/ryanmillergm/received_events","type":"User","site_admin":false},{"login":"n-flint","id":34421236,"node_id":"MDQ6VXNlcjM0NDIxMjM2","avatar_url":"https://avatars3.githubusercontent.com/u/34421236?v=4","gravatar_id":"","url":"https://api.github.com/users/n-flint","html_url":"https://github.com/n-flint","followers_url":"https://api.github.com/users/n-flint/followers","following_url":"https://api.github.com/users/n-flint/following{/other_user}","gists_url":"https://api.github.com/users/n-flint/gists{/gist_id}","starred_url":"https://api.github.com/users/n-flint/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/n-flint/subscriptions","organizations_url":"https://api.github.com/users/n-flint/orgs","repos_url":"https://api.github.com/users/n-flint/repos","events_url":"https://api.github.com/users/n-flint/events{/privacy}","received_events_url":"https://api.github.com/users/n-flint/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:24:58 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/following?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4940'
+      X-Ratelimit-Reset:
+      - '1562894715'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"860bc567e35e6a4bb121ca4217b7420d"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4DC:01B3:AA9A6F:1450259:5D27D36B
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"m-mrcr","id":28820023,"node_id":"MDQ6VXNlcjI4ODIwMDIz","avatar_url":"https://avatars3.githubusercontent.com/u/28820023?v=4","gravatar_id":"","url":"https://api.github.com/users/m-mrcr","html_url":"https://github.com/m-mrcr","followers_url":"https://api.github.com/users/m-mrcr/followers","following_url":"https://api.github.com/users/m-mrcr/following{/other_user}","gists_url":"https://api.github.com/users/m-mrcr/gists{/gist_id}","starred_url":"https://api.github.com/users/m-mrcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/m-mrcr/subscriptions","organizations_url":"https://api.github.com/users/m-mrcr/orgs","repos_url":"https://api.github.com/users/m-mrcr/repos","events_url":"https://api.github.com/users/m-mrcr/events{/privacy}","received_events_url":"https://api.github.com/users/m-mrcr/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false},{"login":"milevy1","id":36040194,"node_id":"MDQ6VXNlcjM2MDQwMTk0","avatar_url":"https://avatars3.githubusercontent.com/u/36040194?v=4","gravatar_id":"","url":"https://api.github.com/users/milevy1","html_url":"https://github.com/milevy1","followers_url":"https://api.github.com/users/milevy1/followers","following_url":"https://api.github.com/users/milevy1/following{/other_user}","gists_url":"https://api.github.com/users/milevy1/gists{/gist_id}","starred_url":"https://api.github.com/users/milevy1/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/milevy1/subscriptions","organizations_url":"https://api.github.com/users/milevy1/orgs","repos_url":"https://api.github.com/users/milevy1/repos","events_url":"https://api.github.com/users/milevy1/events{/privacy}","received_events_url":"https://api.github.com/users/milevy1/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"smainar","id":43945779,"node_id":"MDQ6VXNlcjQzOTQ1Nzc5","avatar_url":"https://avatars3.githubusercontent.com/u/43945779?v=4","gravatar_id":"","url":"https://api.github.com/users/smainar","html_url":"https://github.com/smainar","followers_url":"https://api.github.com/users/smainar/followers","following_url":"https://api.github.com/users/smainar/following{/other_user}","gists_url":"https://api.github.com/users/smainar/gists{/gist_id}","starred_url":"https://api.github.com/users/smainar/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/smainar/subscriptions","organizations_url":"https://api.github.com/users/smainar/orgs","repos_url":"https://api.github.com/users/smainar/repos","events_url":"https://api.github.com/users/smainar/events{/privacy}","received_events_url":"https://api.github.com/users/smainar/received_events","type":"User","site_admin":false},{"login":"carriewalsh","id":43975624,"node_id":"MDQ6VXNlcjQzOTc1NjI0","avatar_url":"https://avatars0.githubusercontent.com/u/43975624?v=4","gravatar_id":"","url":"https://api.github.com/users/carriewalsh","html_url":"https://github.com/carriewalsh","followers_url":"https://api.github.com/users/carriewalsh/followers","following_url":"https://api.github.com/users/carriewalsh/following{/other_user}","gists_url":"https://api.github.com/users/carriewalsh/gists{/gist_id}","starred_url":"https://api.github.com/users/carriewalsh/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/carriewalsh/subscriptions","organizations_url":"https://api.github.com/users/carriewalsh/orgs","repos_url":"https://api.github.com/users/carriewalsh/repos","events_url":"https://api.github.com/users/carriewalsh/events{/privacy}","received_events_url":"https://api.github.com/users/carriewalsh/received_events","type":"User","site_admin":false},{"login":"Loomus","id":44850604,"node_id":"MDQ6VXNlcjQ0ODUwNjA0","avatar_url":"https://avatars0.githubusercontent.com/u/44850604?v=4","gravatar_id":"","url":"https://api.github.com/users/Loomus","html_url":"https://github.com/Loomus","followers_url":"https://api.github.com/users/Loomus/followers","following_url":"https://api.github.com/users/Loomus/following{/other_user}","gists_url":"https://api.github.com/users/Loomus/gists{/gist_id}","starred_url":"https://api.github.com/users/Loomus/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Loomus/subscriptions","organizations_url":"https://api.github.com/users/Loomus/orgs","repos_url":"https://api.github.com/users/Loomus/repos","events_url":"https://api.github.com/users/Loomus/events{/privacy}","received_events_url":"https://api.github.com/users/Loomus/received_events","type":"User","site_admin":false},{"login":"james-cape","id":46202598,"node_id":"MDQ6VXNlcjQ2MjAyNTk4","avatar_url":"https://avatars2.githubusercontent.com/u/46202598?v=4","gravatar_id":"","url":"https://api.github.com/users/james-cape","html_url":"https://github.com/james-cape","followers_url":"https://api.github.com/users/james-cape/followers","following_url":"https://api.github.com/users/james-cape/following{/other_user}","gists_url":"https://api.github.com/users/james-cape/gists{/gist_id}","starred_url":"https://api.github.com/users/james-cape/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/james-cape/subscriptions","organizations_url":"https://api.github.com/users/james-cape/orgs","repos_url":"https://api.github.com/users/james-cape/repos","events_url":"https://api.github.com/users/james-cape/events{/privacy}","received_events_url":"https://api.github.com/users/james-cape/received_events","type":"User","site_admin":false},{"login":"alexander-mathieu","id":47018937,"node_id":"MDQ6VXNlcjQ3MDE4OTM3","avatar_url":"https://avatars3.githubusercontent.com/u/47018937?v=4","gravatar_id":"","url":"https://api.github.com/users/alexander-mathieu","html_url":"https://github.com/alexander-mathieu","followers_url":"https://api.github.com/users/alexander-mathieu/followers","following_url":"https://api.github.com/users/alexander-mathieu/following{/other_user}","gists_url":"https://api.github.com/users/alexander-mathieu/gists{/gist_id}","starred_url":"https://api.github.com/users/alexander-mathieu/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/alexander-mathieu/subscriptions","organizations_url":"https://api.github.com/users/alexander-mathieu/orgs","repos_url":"https://api.github.com/users/alexander-mathieu/repos","events_url":"https://api.github.com/users/alexander-mathieu/events{/privacy}","received_events_url":"https://api.github.com/users/alexander-mathieu/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:24:58 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/MillsProvosty?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4939'
+      X-Ratelimit-Reset:
+      - '1562894715'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"a5dc1860162fafc5c0eaf8d987757d5f"
+      Last-Modified:
+      - Thu, 11 Jul 2019 23:35:46 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4DD:1B4C:402661:A2831B:5D27D36B
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false,"name":"Mills
+        Provosty","company":null,"blog":"","location":"Denver, Co","email":null,"hireable":true,"bio":null,"public_repos":67,"public_gists":16,"followers":7,"following":11,"created_at":"2018-12-13T17:49:09Z","updated_at":"2019-07-11T23:35:46Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:24:58 GMT
+- request:
+    method: get
+    uri: https://api.github.com/users/kylecornelissen?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4938'
+      X-Ratelimit-Reset:
+      - '1562894716'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"4989c1eb43db0d809680f7df95845f22"
+      Last-Modified:
+      - Mon, 08 Jul 2019 18:50:31 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4E2:276C:B9A95F:15A8358:5D27D36C
+    body:
+      encoding: ASCII-8BIT
+      string: '{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false,"name":"Kyle
+        Cornelissen","company":null,"blog":"","location":null,"email":null,"hireable":true,"bio":"Software
+        Developer | Ruby on Rails","public_repos":37,"public_gists":13,"followers":11,"following":25,"created_at":"2018-12-26T23:48:27Z","updated_at":"2019-07-08T18:50:31Z"}'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:24:59 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=1&per_page=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4937'
+      X-Ratelimit-Reset:
+      - '1562894717'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"2cb8a82e98751c79d91daec999a32378"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Link:
+      - <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=2&per_page=5>;
+        rel="next", <https://api.github.com/user/repos?access_token=<GITHUB_API_KEY>&page=15&per_page=5>;
+        rel="last"
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4E4:468C:21757E:58A369:5D27D36C
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":194746869,"node_id":"MDEwOlJlcG9zaXRvcnkxOTQ3NDY4Njk=","name":"brownfield-of-dreams","full_name":"chakeresa/brownfield-of-dreams","private":false,"owner":{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},"html_url":"https://github.com/chakeresa/brownfield-of-dreams","description":"Rails
+        app used for hosting video tutorials and classes. Serves as the base repository
+        for a B3 project.","fork":true,"url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams","forks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/forks","keys_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/keys{/key_id}","collaborators_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/teams","hooks_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/hooks","issue_events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/events{/number}","events_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/events","assignees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/assignees{/user}","branches_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/branches{/branch}","tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/tags","blobs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/refs{/sha}","trees_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/trees{/sha}","statuses_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/statuses/{sha}","languages_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/languages","stargazers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/stargazers","contributors_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contributors","subscribers_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscribers","subscription_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/subscription","commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/commits{/sha}","git_commits_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/git/commits{/sha}","comments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/comments{/number}","issue_comment_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues/comments{/number}","contents_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/contents/{+path}","compare_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/compare/{base}...{head}","merges_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/merges","archive_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/downloads","issues_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/issues{/number}","pulls_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/pulls{/number}","milestones_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/milestones{/number}","notifications_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/labels{/name}","releases_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/releases{/id}","deployments_url":"https://api.github.com/repos/chakeresa/brownfield-of-dreams/deployments","created_at":"2019-07-01T21:43:22Z","updated_at":"2019-07-11T20:54:44Z","pushed_at":"2019-07-12T00:01:23Z","git_url":"git://github.com/chakeresa/brownfield-of-dreams.git","ssh_url":"git@github.com:chakeresa/brownfield-of-dreams.git","clone_url":"https://github.com/chakeresa/brownfield-of-dreams.git","svn_url":"https://github.com/chakeresa/brownfield-of-dreams","homepage":"","size":7735,"stargazers_count":2,"watchers_count":2,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":6,"license":null,"forks":0,"open_issues":6,"watchers":2,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":168045397,"node_id":"MDEwOlJlcG9zaXRvcnkxNjgwNDUzOTc=","name":"battleship","full_name":"jalena-penaligon/battleship","private":false,"owner":{"login":"jalena-penaligon","id":45905026,"node_id":"MDQ6VXNlcjQ1OTA1MDI2","avatar_url":"https://avatars0.githubusercontent.com/u/45905026?v=4","gravatar_id":"","url":"https://api.github.com/users/jalena-penaligon","html_url":"https://github.com/jalena-penaligon","followers_url":"https://api.github.com/users/jalena-penaligon/followers","following_url":"https://api.github.com/users/jalena-penaligon/following{/other_user}","gists_url":"https://api.github.com/users/jalena-penaligon/gists{/gist_id}","starred_url":"https://api.github.com/users/jalena-penaligon/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jalena-penaligon/subscriptions","organizations_url":"https://api.github.com/users/jalena-penaligon/orgs","repos_url":"https://api.github.com/users/jalena-penaligon/repos","events_url":"https://api.github.com/users/jalena-penaligon/events{/privacy}","received_events_url":"https://api.github.com/users/jalena-penaligon/received_events","type":"User","site_admin":false},"html_url":"https://github.com/jalena-penaligon/battleship","description":null,"fork":false,"url":"https://api.github.com/repos/jalena-penaligon/battleship","forks_url":"https://api.github.com/repos/jalena-penaligon/battleship/forks","keys_url":"https://api.github.com/repos/jalena-penaligon/battleship/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jalena-penaligon/battleship/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jalena-penaligon/battleship/teams","hooks_url":"https://api.github.com/repos/jalena-penaligon/battleship/hooks","issue_events_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/events{/number}","events_url":"https://api.github.com/repos/jalena-penaligon/battleship/events","assignees_url":"https://api.github.com/repos/jalena-penaligon/battleship/assignees{/user}","branches_url":"https://api.github.com/repos/jalena-penaligon/battleship/branches{/branch}","tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/tags","blobs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/refs{/sha}","trees_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jalena-penaligon/battleship/statuses/{sha}","languages_url":"https://api.github.com/repos/jalena-penaligon/battleship/languages","stargazers_url":"https://api.github.com/repos/jalena-penaligon/battleship/stargazers","contributors_url":"https://api.github.com/repos/jalena-penaligon/battleship/contributors","subscribers_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscribers","subscription_url":"https://api.github.com/repos/jalena-penaligon/battleship/subscription","commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/commits{/sha}","git_commits_url":"https://api.github.com/repos/jalena-penaligon/battleship/git/commits{/sha}","comments_url":"https://api.github.com/repos/jalena-penaligon/battleship/comments{/number}","issue_comment_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues/comments{/number}","contents_url":"https://api.github.com/repos/jalena-penaligon/battleship/contents/{+path}","compare_url":"https://api.github.com/repos/jalena-penaligon/battleship/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jalena-penaligon/battleship/merges","archive_url":"https://api.github.com/repos/jalena-penaligon/battleship/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jalena-penaligon/battleship/downloads","issues_url":"https://api.github.com/repos/jalena-penaligon/battleship/issues{/number}","pulls_url":"https://api.github.com/repos/jalena-penaligon/battleship/pulls{/number}","milestones_url":"https://api.github.com/repos/jalena-penaligon/battleship/milestones{/number}","notifications_url":"https://api.github.com/repos/jalena-penaligon/battleship/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jalena-penaligon/battleship/labels{/name}","releases_url":"https://api.github.com/repos/jalena-penaligon/battleship/releases{/id}","deployments_url":"https://api.github.com/repos/jalena-penaligon/battleship/deployments","created_at":"2019-01-28T22:04:39Z","updated_at":"2019-02-06T19:57:18Z","pushed_at":"2019-02-06T19:57:17Z","git_url":"git://github.com/jalena-penaligon/battleship.git","ssh_url":"git@github.com:jalena-penaligon/battleship.git","clone_url":"https://github.com/jalena-penaligon/battleship.git","svn_url":"https://github.com/jalena-penaligon/battleship","homepage":null,"size":59,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"forks":0,"open_issues":1,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":176382436,"node_id":"MDEwOlJlcG9zaXRvcnkxNzYzODI0MzY=","name":"Battleship_project","full_name":"kylecornelissen/Battleship_project","private":false,"owner":{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},"html_url":"https://github.com/kylecornelissen/Battleship_project","description":null,"fork":false,"url":"https://api.github.com/repos/kylecornelissen/Battleship_project","forks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/forks","keys_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/keys{/key_id}","collaborators_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/teams","hooks_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/hooks","issue_events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/events{/number}","events_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/events","assignees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/assignees{/user}","branches_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/branches{/branch}","tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/tags","blobs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/refs{/sha}","trees_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/trees{/sha}","statuses_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/statuses/{sha}","languages_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/languages","stargazers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/stargazers","contributors_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contributors","subscribers_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscribers","subscription_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/subscription","commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/commits{/sha}","git_commits_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/git/commits{/sha}","comments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/comments{/number}","issue_comment_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues/comments{/number}","contents_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/contents/{+path}","compare_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/compare/{base}...{head}","merges_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/merges","archive_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/downloads","issues_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/issues{/number}","pulls_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/pulls{/number}","milestones_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/milestones{/number}","notifications_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/labels{/name}","releases_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/releases{/id}","deployments_url":"https://api.github.com/repos/kylecornelissen/Battleship_project/deployments","created_at":"2019-03-18T22:57:32Z","updated_at":"2019-03-28T02:16:44Z","pushed_at":"2019-03-28T02:16:43Z","git_url":"git://github.com/kylecornelissen/Battleship_project.git","ssh_url":"git@github.com:kylecornelissen/Battleship_project.git","clone_url":"https://github.com/kylecornelissen/Battleship_project.git","svn_url":"https://github.com/kylecornelissen/Battleship_project","homepage":null,"size":73,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":true,"pull":true}},{"id":181714029,"node_id":"MDEwOlJlcG9zaXRvcnkxODE3MTQwMjk=","name":"1903_final","full_name":"MillsProvosty/1903_final","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/1903_final","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/1903_final","forks_url":"https://api.github.com/repos/MillsProvosty/1903_final/forks","keys_url":"https://api.github.com/repos/MillsProvosty/1903_final/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/1903_final/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/1903_final/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/1903_final/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/1903_final/events","assignees_url":"https://api.github.com/repos/MillsProvosty/1903_final/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/1903_final/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/1903_final/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/1903_final/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/1903_final/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/1903_final/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/1903_final/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/1903_final/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/1903_final/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/1903_final/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/1903_final/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/1903_final/merges","archive_url":"https://api.github.com/repos/MillsProvosty/1903_final/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/1903_final/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/1903_final/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/1903_final/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/1903_final/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/1903_final/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/1903_final/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/1903_final/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/1903_final/deployments","created_at":"2019-04-16T15:11:02Z","updated_at":"2019-04-16T18:10:48Z","pushed_at":"2019-04-16T18:10:46Z","git_url":"git://github.com/MillsProvosty/1903_final.git","ssh_url":"git@github.com:MillsProvosty/1903_final.git","clone_url":"https://github.com/MillsProvosty/1903_final.git","svn_url":"https://github.com/MillsProvosty/1903_final","homepage":null,"size":8,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}},{"id":184634926,"node_id":"MDEwOlJlcG9zaXRvcnkxODQ2MzQ5MjY=","name":"activerecord-obstacle-course","full_name":"MillsProvosty/activerecord-obstacle-course","private":false,"owner":{"login":"MillsProvosty","id":45856797,"node_id":"MDQ6VXNlcjQ1ODU2Nzk3","avatar_url":"https://avatars3.githubusercontent.com/u/45856797?v=4","gravatar_id":"","url":"https://api.github.com/users/MillsProvosty","html_url":"https://github.com/MillsProvosty","followers_url":"https://api.github.com/users/MillsProvosty/followers","following_url":"https://api.github.com/users/MillsProvosty/following{/other_user}","gists_url":"https://api.github.com/users/MillsProvosty/gists{/gist_id}","starred_url":"https://api.github.com/users/MillsProvosty/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/MillsProvosty/subscriptions","organizations_url":"https://api.github.com/users/MillsProvosty/orgs","repos_url":"https://api.github.com/users/MillsProvosty/repos","events_url":"https://api.github.com/users/MillsProvosty/events{/privacy}","received_events_url":"https://api.github.com/users/MillsProvosty/received_events","type":"User","site_admin":false},"html_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","description":null,"fork":true,"url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course","forks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/forks","keys_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/keys{/key_id}","collaborators_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/teams","hooks_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/hooks","issue_events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/events{/number}","events_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/events","assignees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/assignees{/user}","branches_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/branches{/branch}","tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/tags","blobs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/refs{/sha}","trees_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/trees{/sha}","statuses_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/statuses/{sha}","languages_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/languages","stargazers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/stargazers","contributors_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contributors","subscribers_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscribers","subscription_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/subscription","commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/commits{/sha}","git_commits_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/git/commits{/sha}","comments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/comments{/number}","issue_comment_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues/comments{/number}","contents_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/contents/{+path}","compare_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/compare/{base}...{head}","merges_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/merges","archive_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/downloads","issues_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/issues{/number}","pulls_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/pulls{/number}","milestones_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/milestones{/number}","notifications_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/labels{/name}","releases_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/releases{/id}","deployments_url":"https://api.github.com/repos/MillsProvosty/activerecord-obstacle-course/deployments","created_at":"2019-05-02T18:53:23Z","updated_at":"2019-05-31T17:00:15Z","pushed_at":"2019-05-31T17:00:14Z","git_url":"git://github.com/MillsProvosty/activerecord-obstacle-course.git","ssh_url":"git@github.com:MillsProvosty/activerecord-obstacle-course.git","clone_url":"https://github.com/MillsProvosty/activerecord-obstacle-course.git","svn_url":"https://github.com/MillsProvosty/activerecord-obstacle-course","homepage":null,"size":54,"stargazers_count":0,"watchers_count":0,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":true,"push":true,"pull":true}}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:25:00 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/followers?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4936'
+      X-Ratelimit-Reset:
+      - '1562894717'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"de3cc92700f1038013e3888d075e7b40"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4ED:468D:8D55FE:122CAD5:5D27D36D
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"kylecornelissen","id":46171611,"node_id":"MDQ6VXNlcjQ2MTcxNjEx","avatar_url":"https://avatars2.githubusercontent.com/u/46171611?v=4","gravatar_id":"","url":"https://api.github.com/users/kylecornelissen","html_url":"https://github.com/kylecornelissen","followers_url":"https://api.github.com/users/kylecornelissen/followers","following_url":"https://api.github.com/users/kylecornelissen/following{/other_user}","gists_url":"https://api.github.com/users/kylecornelissen/gists{/gist_id}","starred_url":"https://api.github.com/users/kylecornelissen/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/kylecornelissen/subscriptions","organizations_url":"https://api.github.com/users/kylecornelissen/orgs","repos_url":"https://api.github.com/users/kylecornelissen/repos","events_url":"https://api.github.com/users/kylecornelissen/events{/privacy}","received_events_url":"https://api.github.com/users/kylecornelissen/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"ryanmillergm","id":42855291,"node_id":"MDQ6VXNlcjQyODU1Mjkx","avatar_url":"https://avatars0.githubusercontent.com/u/42855291?v=4","gravatar_id":"","url":"https://api.github.com/users/ryanmillergm","html_url":"https://github.com/ryanmillergm","followers_url":"https://api.github.com/users/ryanmillergm/followers","following_url":"https://api.github.com/users/ryanmillergm/following{/other_user}","gists_url":"https://api.github.com/users/ryanmillergm/gists{/gist_id}","starred_url":"https://api.github.com/users/ryanmillergm/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ryanmillergm/subscriptions","organizations_url":"https://api.github.com/users/ryanmillergm/orgs","repos_url":"https://api.github.com/users/ryanmillergm/repos","events_url":"https://api.github.com/users/ryanmillergm/events{/privacy}","received_events_url":"https://api.github.com/users/ryanmillergm/received_events","type":"User","site_admin":false},{"login":"n-flint","id":34421236,"node_id":"MDQ6VXNlcjM0NDIxMjM2","avatar_url":"https://avatars3.githubusercontent.com/u/34421236?v=4","gravatar_id":"","url":"https://api.github.com/users/n-flint","html_url":"https://github.com/n-flint","followers_url":"https://api.github.com/users/n-flint/followers","following_url":"https://api.github.com/users/n-flint/following{/other_user}","gists_url":"https://api.github.com/users/n-flint/gists{/gist_id}","starred_url":"https://api.github.com/users/n-flint/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/n-flint/subscriptions","organizations_url":"https://api.github.com/users/n-flint/orgs","repos_url":"https://api.github.com/users/n-flint/repos","events_url":"https://api.github.com/users/n-flint/events{/privacy}","received_events_url":"https://api.github.com/users/n-flint/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:25:00 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/following?access_token=<GITHUB_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 12 Jul 2019 00:25:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4935'
+      X-Ratelimit-Reset:
+      - '1562894718'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"860bc567e35e6a4bb121ca4217b7420d"
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - F4EE:01EB:8D4C59:123F25A:5D27D36E
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"login":"m-mrcr","id":28820023,"node_id":"MDQ6VXNlcjI4ODIwMDIz","avatar_url":"https://avatars3.githubusercontent.com/u/28820023?v=4","gravatar_id":"","url":"https://api.github.com/users/m-mrcr","html_url":"https://github.com/m-mrcr","followers_url":"https://api.github.com/users/m-mrcr/followers","following_url":"https://api.github.com/users/m-mrcr/following{/other_user}","gists_url":"https://api.github.com/users/m-mrcr/gists{/gist_id}","starred_url":"https://api.github.com/users/m-mrcr/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/m-mrcr/subscriptions","organizations_url":"https://api.github.com/users/m-mrcr/orgs","repos_url":"https://api.github.com/users/m-mrcr/repos","events_url":"https://api.github.com/users/m-mrcr/events{/privacy}","received_events_url":"https://api.github.com/users/m-mrcr/received_events","type":"User","site_admin":false},{"login":"earl-stephens","id":34906415,"node_id":"MDQ6VXNlcjM0OTA2NDE1","avatar_url":"https://avatars1.githubusercontent.com/u/34906415?v=4","gravatar_id":"","url":"https://api.github.com/users/earl-stephens","html_url":"https://github.com/earl-stephens","followers_url":"https://api.github.com/users/earl-stephens/followers","following_url":"https://api.github.com/users/earl-stephens/following{/other_user}","gists_url":"https://api.github.com/users/earl-stephens/gists{/gist_id}","starred_url":"https://api.github.com/users/earl-stephens/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/earl-stephens/subscriptions","organizations_url":"https://api.github.com/users/earl-stephens/orgs","repos_url":"https://api.github.com/users/earl-stephens/repos","events_url":"https://api.github.com/users/earl-stephens/events{/privacy}","received_events_url":"https://api.github.com/users/earl-stephens/received_events","type":"User","site_admin":false},{"login":"milevy1","id":36040194,"node_id":"MDQ6VXNlcjM2MDQwMTk0","avatar_url":"https://avatars3.githubusercontent.com/u/36040194?v=4","gravatar_id":"","url":"https://api.github.com/users/milevy1","html_url":"https://github.com/milevy1","followers_url":"https://api.github.com/users/milevy1/followers","following_url":"https://api.github.com/users/milevy1/following{/other_user}","gists_url":"https://api.github.com/users/milevy1/gists{/gist_id}","starred_url":"https://api.github.com/users/milevy1/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/milevy1/subscriptions","organizations_url":"https://api.github.com/users/milevy1/orgs","repos_url":"https://api.github.com/users/milevy1/repos","events_url":"https://api.github.com/users/milevy1/events{/privacy}","received_events_url":"https://api.github.com/users/milevy1/received_events","type":"User","site_admin":false},{"login":"Mycobee","id":41843577,"node_id":"MDQ6VXNlcjQxODQzNTc3","avatar_url":"https://avatars3.githubusercontent.com/u/41843577?v=4","gravatar_id":"","url":"https://api.github.com/users/Mycobee","html_url":"https://github.com/Mycobee","followers_url":"https://api.github.com/users/Mycobee/followers","following_url":"https://api.github.com/users/Mycobee/following{/other_user}","gists_url":"https://api.github.com/users/Mycobee/gists{/gist_id}","starred_url":"https://api.github.com/users/Mycobee/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Mycobee/subscriptions","organizations_url":"https://api.github.com/users/Mycobee/orgs","repos_url":"https://api.github.com/users/Mycobee/repos","events_url":"https://api.github.com/users/Mycobee/events{/privacy}","received_events_url":"https://api.github.com/users/Mycobee/received_events","type":"User","site_admin":false},{"login":"bplantico","id":43261385,"node_id":"MDQ6VXNlcjQzMjYxMzg1","avatar_url":"https://avatars3.githubusercontent.com/u/43261385?v=4","gravatar_id":"","url":"https://api.github.com/users/bplantico","html_url":"https://github.com/bplantico","followers_url":"https://api.github.com/users/bplantico/followers","following_url":"https://api.github.com/users/bplantico/following{/other_user}","gists_url":"https://api.github.com/users/bplantico/gists{/gist_id}","starred_url":"https://api.github.com/users/bplantico/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/bplantico/subscriptions","organizations_url":"https://api.github.com/users/bplantico/orgs","repos_url":"https://api.github.com/users/bplantico/repos","events_url":"https://api.github.com/users/bplantico/events{/privacy}","received_events_url":"https://api.github.com/users/bplantico/received_events","type":"User","site_admin":false},{"login":"smainar","id":43945779,"node_id":"MDQ6VXNlcjQzOTQ1Nzc5","avatar_url":"https://avatars3.githubusercontent.com/u/43945779?v=4","gravatar_id":"","url":"https://api.github.com/users/smainar","html_url":"https://github.com/smainar","followers_url":"https://api.github.com/users/smainar/followers","following_url":"https://api.github.com/users/smainar/following{/other_user}","gists_url":"https://api.github.com/users/smainar/gists{/gist_id}","starred_url":"https://api.github.com/users/smainar/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/smainar/subscriptions","organizations_url":"https://api.github.com/users/smainar/orgs","repos_url":"https://api.github.com/users/smainar/repos","events_url":"https://api.github.com/users/smainar/events{/privacy}","received_events_url":"https://api.github.com/users/smainar/received_events","type":"User","site_admin":false},{"login":"carriewalsh","id":43975624,"node_id":"MDQ6VXNlcjQzOTc1NjI0","avatar_url":"https://avatars0.githubusercontent.com/u/43975624?v=4","gravatar_id":"","url":"https://api.github.com/users/carriewalsh","html_url":"https://github.com/carriewalsh","followers_url":"https://api.github.com/users/carriewalsh/followers","following_url":"https://api.github.com/users/carriewalsh/following{/other_user}","gists_url":"https://api.github.com/users/carriewalsh/gists{/gist_id}","starred_url":"https://api.github.com/users/carriewalsh/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/carriewalsh/subscriptions","organizations_url":"https://api.github.com/users/carriewalsh/orgs","repos_url":"https://api.github.com/users/carriewalsh/repos","events_url":"https://api.github.com/users/carriewalsh/events{/privacy}","received_events_url":"https://api.github.com/users/carriewalsh/received_events","type":"User","site_admin":false},{"login":"Loomus","id":44850604,"node_id":"MDQ6VXNlcjQ0ODUwNjA0","avatar_url":"https://avatars0.githubusercontent.com/u/44850604?v=4","gravatar_id":"","url":"https://api.github.com/users/Loomus","html_url":"https://github.com/Loomus","followers_url":"https://api.github.com/users/Loomus/followers","following_url":"https://api.github.com/users/Loomus/following{/other_user}","gists_url":"https://api.github.com/users/Loomus/gists{/gist_id}","starred_url":"https://api.github.com/users/Loomus/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/Loomus/subscriptions","organizations_url":"https://api.github.com/users/Loomus/orgs","repos_url":"https://api.github.com/users/Loomus/repos","events_url":"https://api.github.com/users/Loomus/events{/privacy}","received_events_url":"https://api.github.com/users/Loomus/received_events","type":"User","site_admin":false},{"login":"james-cape","id":46202598,"node_id":"MDQ6VXNlcjQ2MjAyNTk4","avatar_url":"https://avatars2.githubusercontent.com/u/46202598?v=4","gravatar_id":"","url":"https://api.github.com/users/james-cape","html_url":"https://github.com/james-cape","followers_url":"https://api.github.com/users/james-cape/followers","following_url":"https://api.github.com/users/james-cape/following{/other_user}","gists_url":"https://api.github.com/users/james-cape/gists{/gist_id}","starred_url":"https://api.github.com/users/james-cape/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/james-cape/subscriptions","organizations_url":"https://api.github.com/users/james-cape/orgs","repos_url":"https://api.github.com/users/james-cape/repos","events_url":"https://api.github.com/users/james-cape/events{/privacy}","received_events_url":"https://api.github.com/users/james-cape/received_events","type":"User","site_admin":false},{"login":"alexander-mathieu","id":47018937,"node_id":"MDQ6VXNlcjQ3MDE4OTM3","avatar_url":"https://avatars3.githubusercontent.com/u/47018937?v=4","gravatar_id":"","url":"https://api.github.com/users/alexander-mathieu","html_url":"https://github.com/alexander-mathieu","followers_url":"https://api.github.com/users/alexander-mathieu/followers","following_url":"https://api.github.com/users/alexander-mathieu/following{/other_user}","gists_url":"https://api.github.com/users/alexander-mathieu/gists{/gist_id}","starred_url":"https://api.github.com/users/alexander-mathieu/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/alexander-mathieu/subscriptions","organizations_url":"https://api.github.com/users/alexander-mathieu/orgs","repos_url":"https://api.github.com/users/alexander-mathieu/repos","events_url":"https://api.github.com/users/alexander-mathieu/events{/privacy}","received_events_url":"https://api.github.com/users/alexander-mathieu/received_events","type":"User","site_admin":false},{"login":"chakeresa","id":<GITHUB_UID>,"node_id":"MDQ6VXNlcjQ3MzA5ODYx","avatar_url":"https://avatars2.githubusercontent.com/u/<GITHUB_UID>?v=4","gravatar_id":"","url":"https://api.github.com/users/chakeresa","html_url":"https://github.com/chakeresa","followers_url":"https://api.github.com/users/chakeresa/followers","following_url":"https://api.github.com/users/chakeresa/following{/other_user}","gists_url":"https://api.github.com/users/chakeresa/gists{/gist_id}","starred_url":"https://api.github.com/users/chakeresa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/chakeresa/subscriptions","organizations_url":"https://api.github.com/users/chakeresa/orgs","repos_url":"https://api.github.com/users/chakeresa/repos","events_url":"https://api.github.com/users/chakeresa/events{/privacy}","received_events_url":"https://api.github.com/users/chakeresa/received_events","type":"User","site_admin":false}]'
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 00:25:01 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/visitor_no_clasroom_tutorials.yml
+++ b/spec/cassettes/visitor_no_clasroom_tutorials.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://chromedriver.storage.googleapis.com/LATEST_RELEASE_75.0.3770
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - chromedriver.storage.googleapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UrRb3JXFg6VOm-3lGutmukxfRP9qbk5HzCZon0z7rqPrg7hTUMkN49MVZ63fWR46fZlNCRho3nq02z6TovtPlcV2ZAWYRMO-6niTyia3_UcMuQPKCU
+      Expires:
+      - Fri, 12 Jul 2019 16:12:51 GMT
+      Date:
+      - Fri, 12 Jul 2019 15:12:51 GMT
+      Last-Modified:
+      - Thu, 13 Jun 2019 21:21:19 GMT
+      Etag:
+      - '"f6526b177e51743e04eab2b42debcb62"'
+      X-Goog-Generation:
+      - '1560460879513580'
+      X-Goog-Metageneration:
+      - '1'
+      X-Goog-Stored-Content-Encoding:
+      - identity
+      X-Goog-Stored-Content-Length:
+      - '12'
+      Content-Type:
+      - text/plain
+      Content-Language:
+      - en
+      X-Goog-Hash:
+      - crc32c=FBQBjg==
+      - md5=9lJrF35RdD4E6rK0LevLYg==
+      X-Goog-Storage-Class:
+      - STANDARD
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '12'
+      Server:
+      - UploadServer
+      Cache-Control:
+      - public, max-age=3600
+      Age:
+      - '1623'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: UTF-8
+      string: 75.0.3770.90
+    http_version: 
+  recorded_at: Fri, 12 Jul 2019 15:39:36 GMT
+recorded_with: VCR 5.0.0

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
 
   factory :user_with_github, parent: :user do
     github_token { ENV['GITHUB_API_KEY'] }
+    github_handle { 'MillsProvosty' }
   end
 
   factory :admin, parent: :user do

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -8,7 +8,7 @@ describe 'As a registered user on my dashboard page' do
       WebMock.allow_net_connect!
       VCR.turn_off!
 
-      user = create(:user)
+      user = create(:user_with_github)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit '/dashboard'
@@ -16,8 +16,8 @@ describe 'As a registered user on my dashboard page' do
 
       expect(current_path).to eq('/invite')
       
-      fill_in :github_handle, with: 'kylecornelissen'
-      expect { click_button 'Send Invite' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      fill_in :github_handle, with: 'chakeresa'
+      expect { click_button 'Send Invite'; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content('Successfully sent invite!')

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -35,6 +35,21 @@ describe 'As a registered user (authorized with github) on my dashboard page' do
       expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
     end
   end
+  
+  it 'I see a message if I enter an invalid github handle' do
+    VCR.use_cassette('invite_invalid_github_handle', record: :new_episodes) do
+      visit '/dashboard'
+      click_link 'Send an Invite'
+
+      invitee_handle = 'MillsProvosty111'
+      
+      fill_in :github_handle, with: invitee_handle
+      expect { click_button 'Send Invite'; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(0)
+      
+      expect(current_path).to eq('/dashboard')
+      expect(page).to have_content("Failed to find the Github user with handle #{invitee_handle}")
+    end
+  end
 end
 
 describe 'As a registered user (not authorized with github) on my dashboard page' do

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -53,13 +53,11 @@ describe 'As a registered user (authorized with github) on my dashboard page' do
 end
 
 describe 'As a registered user (not authorized with github) on my dashboard page' do
-  before(:each) do
-    user = create(:user)
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-  end
-
   it 'I cannot invite a github user' do
     VCR.use_cassette('no_invite_button_for_non_github_user', record: :new_episodes) do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      
       visit '/dashboard'
 
       expect(page).to_not have_link('Send an Invite')

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -17,7 +17,7 @@ describe 'As a registered user on my dashboard page' do
       expect(current_path).to eq('/invite')
       
       fill_in :github_handle, with: 'kylecornelissen'
-      click_button 'Send Invite'
+      expect { click_button 'Send Invite' }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content('Successfully sent invite!')

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'As a registered user on my dashboard page' do
+  it 'I can invite a github user' do
+    # VCR.use_cassette('invite_github_user', record: :new_episodes) do
+      WebMock.allow_net_connect!
+      VCR.turn_off!
+
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/dashboard'
+      click_link 'Send an Invite'
+
+      expect(current_path).to eq('/invite')
+      
+      fill_in 'some field', with: 'kylecornelissen'
+      click_button 'Send Invite'
+
+      expect(current_path).to eq('/dashboard')
+      expect(page).to have_content('Successfully sent invite!')
+    # end
+  end
+
+# Background: We want to be able to enter a user's Github handle and send them an email invite to our app. You'll use the Github API to retrieve the email address of the invitee.
+# Or I should see a message that says "The Github user you selected doesn't have an email address associated with their account."

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -23,6 +23,7 @@ describe 'As a registered user on my dashboard page' do
       expect(page).to have_content('Successfully sent invite!')
     # end
   end
+end
 
 # Background: We want to be able to enter a user's Github handle and send them an email invite to our app. You'll use the Github API to retrieve the email address of the invitee.
 # Or I should see a message that says "The Github user you selected doesn't have an email address associated with their account."

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -4,10 +4,7 @@ require 'rails_helper'
 
 describe 'As a registered user on my dashboard page' do
   it 'I can invite a github user' do
-    # VCR.use_cassette('invite_github_user', record: :new_episodes) do
-      WebMock.allow_net_connect!
-      VCR.turn_off!
-
+    VCR.use_cassette('invite_github_user', record: :new_episodes) do
       user = create(:user_with_github)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -21,7 +18,7 @@ describe 'As a registered user on my dashboard page' do
 
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content('Successfully sent invite!')
-    # end
+    end
   end
 end
 

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'As a registered user on my dashboard page' do
+describe 'As a registered user (authorized with github) on my dashboard page' do
   before(:each) do
     user = create(:user_with_github)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
@@ -22,17 +22,32 @@ describe 'As a registered user on my dashboard page' do
       expect(page).to have_content('Successfully sent invite!')
     end
   end
-
+  
   it 'I cannot invite a github user with a private email' do
     VCR.use_cassette('invite_private_github_user', record: :new_episodes) do
       visit '/dashboard'
       click_link 'Send an Invite'
-
+      
       fill_in :github_handle, with: 'kylecornelissen'
       expect { click_button 'Send Invite'; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(0)
-
+      
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+    end
+  end
+end
+
+describe 'As a registered user (not authorized with github) on my dashboard page' do
+  before(:each) do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  end
+
+  it 'I cannot invite a github user' do
+    VCR.use_cassette('no_invite_button_for_non_github_user', record: :new_episodes) do
+      visit '/dashboard'
+
+      expect(page).to_not have_link('Send an Invite')
     end
   end
 end

--- a/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_to_our_site_spec.rb
@@ -16,7 +16,7 @@ describe 'As a registered user on my dashboard page' do
 
       expect(current_path).to eq('/invite')
       
-      fill_in 'some field', with: 'kylecornelissen'
+      fill_in :github_handle, with: 'kylecornelissen'
       click_button 'Send Invite'
 
       expect(current_path).to eq('/dashboard')

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -27,7 +27,8 @@ describe 'visitor can create an account', :js do
       fill_in 'user[password]', with: password
       fill_in 'user[password_confirmation]', with: password
 
-      click_on'Create Account'
+      # click_on'Create Account'
+      expect { click_on 'Create Account'; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(current_path).to eq(dashboard_path)
 

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -27,7 +27,6 @@ describe 'visitor can create an account', :js do
       fill_in 'user[password]', with: password
       fill_in 'user[password_confirmation]', with: password
 
-      # click_on'Create Account'
       expect { click_on 'Create Account'; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
       expect(current_path).to eq(dashboard_path)

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe UserMailer, type: :mailer do
     before :each do
       inviter_attr = { full_name: 'Alexandra Chakeres' }
       invitee_attr = { full_name: 'Kyle Cornelissen', email: 'kyle@gmail.com' }
-      @inviter = GitHubUser.new(inviter_attr)
-      @invitee = GitHubUser.new(invitee_attr)
+      @inviter = GithubUser.new(inviter_attr)
+      @invitee = GithubUser.new(invitee_attr)
       @mail = UserMailer.invite_email(@inviter, @invitee)
     end
 

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -17,4 +17,24 @@ RSpec.describe UserMailer, type: :mailer do
       expect(@mail.body.encoded).to match("Visit here to activate your account.")
     end
   end
+
+  describe "invite email to a github user" do
+    before :each do
+      inviter_attr = { full_name: 'Alexandra Chakeres' }
+      invitee_attr = { full_name: 'Kyle Cornelissen', email: 'kyle@gmail.com' }
+      @inviter = GitHubUser.new(inviter_attr)
+      @invitee = GitHubUser.new(invitee_attr)
+      @mail = UserMailer.invite_email(@inviter, @invitee)
+    end
+
+    it "renders the headers" do
+      expect(@mail.subject).to eq("Join Brownfield of Dreams!")
+      expect(@mail.to).to eq([@invitee.email])
+      expect(@mail.from).to eq(["no_reply@brownfieldofdreams.com"])
+    end
+
+    it "renders the body" do
+      expect(@mail.body.encoded).to match("Hello #{@invitee.full_name},\n#{@inviter.full_name} has invited you to join Brownfield of Dreams. You can create an account here.")
+    end
+  end
 end

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(@mail.body.encoded).to match("Hello #{@invitee_name},\n#{@inviter_name} has invited you to join Brownfield of Dreams. You can create an account here.")
+      expect(@mail.body.encoded).to have_content("Hello #{@invitee_name},")
+      expect(@mail.body.encoded).to have_content("#{@inviter_name} has invited you to join Brownfield of Dreams. You can create an account here.")
     end
   end
 end

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -20,21 +20,20 @@ RSpec.describe UserMailer, type: :mailer do
 
   describe "invite email to a github user" do
     before :each do
-      inviter_attr = { full_name: 'Alexandra Chakeres' }
-      invitee_attr = { full_name: 'Kyle Cornelissen', email: 'kyle@gmail.com' }
-      @inviter = GithubUser.new(inviter_attr)
-      @invitee = GithubUser.new(invitee_attr)
-      @mail = UserMailer.invite_email(@inviter, @invitee)
+      @inviter_name = "Mills Provosty"
+      @invitee_name = "Alexandra Chakeres"
+      @invitee_email = "test@example.com"
+      @mail = UserMailer.invite_email(@inviter_name, @invitee_name, @invitee_email)
     end
 
     it "renders the headers" do
       expect(@mail.subject).to eq("Join Brownfield of Dreams!")
-      expect(@mail.to).to eq([@invitee.email])
+      expect(@mail.to).to eq([@invitee_email])
       expect(@mail.from).to eq(["no_reply@brownfieldofdreams.com"])
     end
 
     it "renders the body" do
-      expect(@mail.body.encoded).to match("Hello #{@invitee.full_name},\n#{@inviter.full_name} has invited you to join Brownfield of Dreams. You can create an account here.")
+      expect(@mail.body.encoded).to match("Hello #{@invitee_name},\n#{@inviter_name} has invited you to join Brownfield of Dreams. You can create an account here.")
     end
   end
 end

--- a/spec/models/invite_maker_spec.rb
+++ b/spec/models/invite_maker_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InviteMaker, type: :model do
+  before(:each) do 
+    @current_user = create(:user_with_github)
+  end
+
+  it "exists" do
+    invite_maker = InviteMaker.new(@current_user, "kyle")
+    expect(invite_maker).to be_a(InviteMaker)
+    expect(invite_maker.flash).to eq(nil)
+  end
+
+  describe "#setup_email" do
+    it 'sends email when invitee_handle is a valid github handle and the user has a public email' do
+      VCR.use_cassette('invite_maker_valid_github_handle', record: :new_episodes) do
+        invite_maker = InviteMaker.new(@current_user, "chakeresa")
+        expected_flash = { success: 'Successfully sent invite!' }
+
+        expect { invite_maker.setup_email; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect(invite_maker.flash).to eq(expected_flash)
+      end
+    end
+
+    it 'does not send email when invitee_handle is a valid github handle but the user has a private email' do
+      VCR.use_cassette('invite_maker_github_handle_with_private_email', record: :new_episodes) do
+        invite_maker = InviteMaker.new(@current_user, 'MillsProvosty')
+        expected_flash = { danger: "The Github user you selected doesn't have an email address associated with their account." }
+        
+        expect { invite_maker.setup_email; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        expect(invite_maker.flash).to eq(expected_flash)
+      end
+    end
+    
+    it 'does not send email when invitee_handle is not a valid github handle' do
+      VCR.use_cassette('invite_maker_invalid_github_handle', record: :new_episodes) do
+        bad_handle = 'MillsProvosty1111'
+        invite_maker = InviteMaker.new(@current_user, bad_handle)
+        expected_flash = { danger: "Failed to find the Github user with handle #{bad_handle}" }
+
+        expect { invite_maker.setup_email; sleep 1 }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        expect(invite_maker.flash).to eq(expected_flash)
+      end
+    end
+  end
+end

--- a/spec/services/github_api_service_spec.rb
+++ b/spec/services/github_api_service_spec.rb
@@ -42,4 +42,13 @@ describe GithubApiService do
       expect(users_followed.count).to eq(6)
     end
   end
+
+  it '#user_attributes' do
+    VCR.use_cassette('github_api_user_attributes', record: :new_episodes) do
+      user_attributes = @service.user_attributes('chakeresa')
+      expect(user_attributes).to be_a(Hash)
+      expect(user_attributes).to have_key(:name)
+      expect(user_attributes).to have_key(:email)
+    end
+  end
 end


### PR DESCRIPTION
This branch...
 - Resolves #6 (email invitations)
 - Adds button to dashboard of github-authorized users to invite other github users, and associated form to input github handle
 - Adds `InvitesController#new` & `#create`
 - Adds `UserMailer#invite_email` & associated view (email)
 - Adds `InviteMaker` PORO to assist `InvitesController#create`
 - Adds `GithubApiService#user_attributes`
 - Tests all of the above